### PR TITLE
Make buildpack generate requirements.txt

### DIFF
--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+export POETRY_VERSION=1.0.0
+curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+source $HOME/.poetry/env
+poetry export --without-hashes -f requirements.txt -o requirements.txt

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
   services:
     - legal-basis-api-dev
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
   env:
     DJANGO_ENV: "production"
     DJANGO_SECRET_KEY: "secret"


### PR DESCRIPTION
This makes the buildpack generate requirements in a standalone way so that we
don't have to:

  1. check it in
  2. generate it in Jenkins