### PR TITLE
Add Bandit security linter

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: ./.venv,./tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,10 @@ jobs:
           command: poetry run safety check --bare --full-report
 
       - run:
+          name: Run Bandit security linter
+          command: poetry run bandit -r .
+
+      - run:
           name: Check pyproject.toml
           command: poetry check
 

--- a/docker/ci.sh
+++ b/docker/ci.sh
@@ -53,6 +53,9 @@ run_ci () {
   # known vulnerabilities:
   safety check --bare --full-report
 
+  # Bandit security linting
+  bandit -r .
+
   # Checking `pyproject.toml` file contents:
   poetry check
 
@@ -63,7 +66,7 @@ run_ci () {
   doc8 -q docs
 
   # Checking `yaml` files:
-  yamllint -d '{"extends": "default", "ignore": ".venv"}' -s .
+  yamllint -s .
 
   echo '[ci finished]'
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,6 +94,21 @@ python-versions = "*"
 version = "0.1.0"
 
 [[package]]
+category = "dev"
+description = "Security oriented static analyser for python code."
+name = "bandit"
+optional = false
+python-versions = "*"
+version = "1.6.2"
+
+[package.dependencies]
+GitPython = ">=1.0.1"
+PyYAML = ">=3.13"
+colorama = ">=0.3.9"
+six = ">=1.10.0"
+stevedore = ">=1.20.0"
+
+[[package]]
 category = "main"
 description = "Modern password hashing for your software and your servers"
 name = "bcrypt"
@@ -651,6 +666,28 @@ version = "0.1.3"
 
 [package.dependencies]
 flake8-plugin-utils = ">=1.0,<2.0"
+
+[[package]]
+category = "dev"
+description = "Git Object Database"
+name = "gitdb2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.0.6"
+
+[package.dependencies]
+smmap2 = ">=2.0.0"
+
+[[package]]
+category = "dev"
+description = "Python Git Library"
+name = "gitpython"
+optional = false
+python-versions = ">=3.0, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.0.5"
+
+[package.dependencies]
+gitdb2 = ">=2.0.0"
 
 [[package]]
 category = "main"
@@ -1399,6 +1436,14 @@ version = "1.13.0"
 
 [[package]]
 category = "dev"
+description = "A pure Python implementation of a sliding window memory map manager"
+name = "smmap2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.0.5"
+
+[[package]]
+category = "dev"
 description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
 name = "snowballstemmer"
 optional = false
@@ -1735,7 +1780,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "6e94ae0c8bac98914c9e5d20f8bacbd377c5abfb81087d20773300ab95707cb0"
+content-hash = "c13708902d77b63ccfd3c60d19fc1980f161079ddcbcefdf20113fab2800dbbf"
 python-versions = "3.7.*"
 
 [metadata.files]
@@ -1773,6 +1818,10 @@ babel = [
 backcall = [
     {file = "backcall-0.1.0.tar.gz", hash = "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4"},
     {file = "backcall-0.1.0.zip", hash = "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"},
+]
+bandit = [
+    {file = "bandit-1.6.2-py2.py3-none-any.whl", hash = "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952"},
+    {file = "bandit-1.6.2.tar.gz", hash = "sha256:41e75315853507aa145d62a78a2a6c5e3240fe14ee7c601459d0df9418196065"},
 ]
 bcrypt = [
     {file = "bcrypt-3.1.7-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:d7bdc26475679dd073ba0ed2766445bb5b20ca4793ca0db32b399dccc6bc84b7"},
@@ -2066,6 +2115,14 @@ flake8-pytest = [
 flake8-pytest-style = [
     {file = "flake8-pytest-style-0.1.3.tar.gz", hash = "sha256:820503cb50b7f6aa13a9889f4c47ba35bbd666877a72ed138ae5682a9bccaf9d"},
     {file = "flake8_pytest_style-0.1.3-py3-none-any.whl", hash = "sha256:1c2303998c509cd65c3fb047cd536787ddf953e8113bc7f086c0cd7468db4b1f"},
+]
+gitdb2 = [
+    {file = "gitdb2-2.0.6-py2.py3-none-any.whl", hash = "sha256:96bbb507d765a7f51eb802554a9cfe194a174582f772e0d89f4e87288c288b7b"},
+    {file = "gitdb2-2.0.6.tar.gz", hash = "sha256:1b6df1433567a51a4a9c1a5a0de977aa351a405cc56d7d35f3388bad1f630350"},
+]
+gitpython = [
+    {file = "GitPython-3.0.5-py3-none-any.whl", hash = "sha256:c155c6a2653593ccb300462f6ef533583a913e17857cfef8fc617c246b6dc245"},
+    {file = "GitPython-3.0.5.tar.gz", hash = "sha256:9c2398ffc3dcb3c40b27324b316f08a4f93ad646d5a6328cafbb871aa79f5e42"},
 ]
 hawkrest = [
     {file = "hawkrest-1.0.1-py2.py3-none-any.whl", hash = "sha256:e93f8fe322bfe04967a6ab37a8794246d8550b679c70b80fa655e89f9706f213"},
@@ -2439,6 +2496,10 @@ sentry-sdk = [
 six = [
     {file = "six-1.13.0-py2.py3-none-any.whl", hash = "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd"},
     {file = "six-1.13.0.tar.gz", hash = "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"},
+]
+smmap2 = [
+    {file = "smmap2-2.0.5-py2.py3-none-any.whl", hash = "sha256:0555a7bf4df71d1ef4218e4807bbf9b201f910174e6e08af2e138d4e517b4dde"},
+    {file = "smmap2-2.0.5.tar.gz", hash = "sha256:29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,4 @@ flake8-isort = "^2.8.0"
 black = {version = "^19.10b0", allow-prereleases = true}
 pylint = "^2.4.4"
 autopep8 = "^1.4.4"
+bandit = "^1.6.2"

--- a/server/settings/environments/production.py
+++ b/server/settings/environments/production.py
@@ -27,7 +27,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 
-_PASS = "django.contrib.auth.password_validation"  # noqa: S105
+_PASS = "django.contrib.auth.password_validation"  # nosec noqa: S105
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "{0}.UserAttributeSimilarityValidator".format(_PASS)},
     {"NAME": "{0}.MinimumLengthValidator".format(_PASS)},


### PR DESCRIPTION
Added as a separate tool rather than as a flake8 plugin, as `flake8-bandit` seems to do literally nothing.

[Example output with no errors](https://app.circleci.com/jobs/github/uktrade/legal-basis-api/52/parallel-runs/0/steps/0-114)
[Example output with error](https://app.circleci.com/jobs/github/uktrade/legal-basis-api/51/parallel-runs/0/steps/0-114)

Not sure how useful this actually is, but it seems worth trying out?