### PR TITLE
Replace python-decouple with django-environ

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -1,18 +1,16 @@
-Django
-======
+# Django
 
-Configuration
--------------
+## Configuration
 
 We share the same configuration structure for almost every possible
 environment.
 
 We use:
 
--   `django-split-settings` to organize `django` settings into multiple
-    files and directories
--   `.env` files to store secret configuration
--   `python-decouple` to load `.env` files into `django`
+- `django-split-settings` to organize `django` settings into multiple
+  files and directories
+- `.env` files to store secret configuration
+- `python-decouple` to load `.env` files into `django`
 
 ### Components
 
@@ -35,14 +33,13 @@ file `server/settings/environments/local.py.template` to
 `server/settings/environments/local.py`. It will be loaded into your
 settings automatically if exists.
 
-``` {.sourceCode .bash}
+```{.sourceCode .bash}
 cp server/settings/environments/local.py.template server/settings/environments/local.py
 ```
 
 See `local.py.template` version for the reference.
 
-Secret settings
----------------
+## Secret settings
 
 We share the same mechanism for secret settings for all our tools. We
 use `.env` files for `django`, `postgres`, `docker`, etc.
@@ -50,7 +47,7 @@ use `.env` files for `django`, `postgres`, `docker`, etc.
 Initially, you will need to copy file `config/.env.template` to
 `config/.env`:
 
-``` {.sourceCode .bash}
+```{.sourceCode .bash}
 cp config/.env.template config/.env
 ```
 
@@ -60,8 +57,8 @@ When adding any new secret `django` settings you will need to:
 2.  Add new key without value to `config/.env.template`, add a comment
     on how to get this value for other users
 3.  Add new variable inside `django` settings
-4.  Use `python-decouple` to load this `env` variable like so:
-    `MY_SECRET = config('MY_SECRET')`
+4.  Use `django-environ` to load this `env` variable like so:
+    `MY_SECRET = env('MY_SECRET')`
 
 ### Secret settings in production
 
@@ -84,72 +81,69 @@ Here's an example:
 2.  Then `dump-env` dumps `SECRET_DJANGO_SECRET_KEY` as
     `DJANGO_SECRET_KEY` and writes it to `config/.env` file
 3.  Then it is loaded by `django` inside the settings:
-    `SECRET_KEY = config('DJANGO_SECRET_KEY')`
+    `SECRET_KEY = env('DJANGO_SECRET_KEY')`
 
 However, there are different options to store secret settings:
 
--   [ansible-vault](https://docs.ansible.com/ansible/2.4/vault.html)
--   [git-secret](https://github.com/sobolevn/git-secret)
--   [Vault](https://www.vaultproject.io/)
+- [ansible-vault](https://docs.ansible.com/ansible/2.4/vault.html)
+- [git-secret](https://github.com/sobolevn/git-secret)
+- [Vault](https://www.vaultproject.io/)
 
 Depending on a project we use different tools. With `dump-env` being the
 default and the simplest one.
 
-Extensions
-----------
+## Extensions
 
 We use different `django` extensions that make your life easier. Here's
 a full list of the extensions for both development and production:
 
--   [django-split-settings](https://github.com/sobolevn/django-split-settings) -
-    organize `django` settings into multiple files and directories.
-    Easily override and modify settings. Use wildcards in settings file
-    paths and mark settings files as optional
--   [django-axes](https://github.com/jazzband/django-axes) - keep track
-    of failed login attempts in `django` powered sites
--   [django-csp](https://github.com/mozilla/django-csp) - [Content
-    Security
-    Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
-    for `django`
--   [django-referrer-policy](https://github.com/ubernostrum/django-referrer-policy) -
-    middleware implementing the
-    [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
--   [django-health-check](https://github.com/KristianOellegaard/django-health-check) -
-    checks for various conditions and provides reports when anomalous
-    behavior is detected
--   [django-add-default-value](https://github.com/3YOURMIND/django-add-default-value) -
-    this django Migration Operation can be used to transfer a Fields
-    default value to the database scheme
--   [django-deprecate-fields](https://github.com/3YOURMIND/django-deprecate-fields) -
-    this package allows deprecating model fields and allows removing
-    them in a backwards compatible manner
--   [django-migration-linter](https://github.com/3YOURMIND/django-migration-linter) -
-    detect backward incompatible migrations for your django project
--   [zero-downtime-migrations](https://github.com/yandex/zero-downtime-migrations) -
-    apply `django` migrations on PostgreSql without long locks on tables
+- [django-split-settings](https://github.com/sobolevn/django-split-settings) -
+  organize `django` settings into multiple files and directories.
+  Easily override and modify settings. Use wildcards in settings file
+  paths and mark settings files as optional
+- [django-axes](https://github.com/jazzband/django-axes) - keep track
+  of failed login attempts in `django` powered sites
+- [django-csp](https://github.com/mozilla/django-csp) - [Content
+  Security
+  Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+  for `django`
+- [django-referrer-policy](https://github.com/ubernostrum/django-referrer-policy) -
+  middleware implementing the
+  [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
+- [django-health-check](https://github.com/KristianOellegaard/django-health-check) -
+  checks for various conditions and provides reports when anomalous
+  behavior is detected
+- [django-add-default-value](https://github.com/3YOURMIND/django-add-default-value) -
+  this django Migration Operation can be used to transfer a Fields
+  default value to the database scheme
+- [django-deprecate-fields](https://github.com/3YOURMIND/django-deprecate-fields) -
+  this package allows deprecating model fields and allows removing
+  them in a backwards compatible manner
+- [django-migration-linter](https://github.com/3YOURMIND/django-migration-linter) -
+  detect backward incompatible migrations for your django project
+- [zero-downtime-migrations](https://github.com/yandex/zero-downtime-migrations) -
+  apply `django` migrations on PostgreSql without long locks on tables
 
 Development only extensions:
 
--   [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar) -
-    a configurable set of panels that display various debug information
-    about the current request/response
--   [django-querycount](https://github.com/bradmontgomery/django-querycount) -
-    middleware that prints the number of DB queries to the runserver
-    console
--   [nplusone](https://github.com/jmcarp/nplusone) - auto-detecting the
-    [n+1 queries
-    problem](https://stackoverflow.com/questions/97197/what-is-the-n1-select-query-issue)
-    in `django`
+- [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar) -
+  a configurable set of panels that display various debug information
+  about the current request/response
+- [django-querycount](https://github.com/bradmontgomery/django-querycount) -
+  middleware that prints the number of DB queries to the runserver
+  console
+- [nplusone](https://github.com/jmcarp/nplusone) - auto-detecting the
+  [n+1 queries
+  problem](https://stackoverflow.com/questions/97197/what-is-the-n1-select-query-issue)
+  in `django`
 
-Further reading
----------------
+## Further reading
 
--   [django-split-settings
-    tutorial](https://medium.com/wemake-services/managing-djangos-settings-e2b7f496120d)
--   [docker env-file docs](https://docs.docker.com/compose/env-file/)
+- [django-split-settings
+  tutorial](https://medium.com/wemake-services/managing-djangos-settings-e2b7f496120d)
+- [docker env-file docs](https://docs.docker.com/compose/env-file/)
 
 ### Django admin
 
--   [Django Admin
-    Cookbook](https://books.agiliq.com/projects/django-admin-cookbook/en/latest/)
-
+- [Django Admin
+  Cookbook](https://books.agiliq.com/projects/django-admin-cookbook/en/latest/)

--- a/poetry.lock
+++ b/poetry.lock
@@ -256,14 +256,6 @@ version = "4.4.1"
 
 [[package]]
 category = "main"
-description = "Use Database URLs in your Django Application."
-name = "dj-database-url"
-optional = false
-python-versions = "*"
-version = "0.5.0"
-
-[[package]]
-category = "main"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 name = "django"
 optional = false
@@ -356,6 +348,14 @@ version = "2.1"
 [package.dependencies]
 Django = ">=1.11"
 sqlparse = ">=0.2.0"
+
+[[package]]
+category = "main"
+description = "Django-environ allows you to utilize 12factor inspired environment variables to configure your Django application."
+name = "django-environ"
+optional = false
+python-versions = "*"
+version = "0.4.5"
 
 [[package]]
 category = "dev"
@@ -1287,14 +1287,6 @@ pytest = ">=3.6.0"
 
 [[package]]
 category = "main"
-description = "Strict separation of settings from code."
-name = "python-decouple"
-optional = false
-python-versions = "*"
-version = "3.3"
-
-[[package]]
-category = "main"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
@@ -1795,7 +1787,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "5556c11aeefcb3c983d66a1697fdb4d5896b43ac5490a073d1266e066e0c86bd"
+content-hash = "c6df61251c9189340507ad5a14306d2e0e38603b3a3dbf2f15c8fc31c5381f07"
 python-versions = "3.7.*"
 
 [metadata.files]
@@ -2000,10 +1992,6 @@ decorator = [
     {file = "decorator-4.4.1-py2.py3-none-any.whl", hash = "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"},
     {file = "decorator-4.4.1.tar.gz", hash = "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce"},
 ]
-dj-database-url = [
-    {file = "dj-database-url-0.5.0.tar.gz", hash = "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163"},
-    {file = "dj_database_url-0.5.0-py2.py3-none-any.whl", hash = "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"},
-]
 django = [
     {file = "Django-2.2.9-py3-none-any.whl", hash = "sha256:687c37153486cf26c3fdcbdd177ef16de38dc3463f094b5f9c9955d91f277b14"},
     {file = "Django-2.2.9.tar.gz", hash = "sha256:662a1ff78792e3fd77f16f71b1f31149489434de4b62a74895bd5d6534e635a5"},
@@ -2030,6 +2018,10 @@ django-csp = [
 django-debug-toolbar = [
     {file = "django-debug-toolbar-2.1.tar.gz", hash = "sha256:24c157bc6c0e1648e0a6587511ecb1b007a00a354ce716950bff2de12693e7a8"},
     {file = "django_debug_toolbar-2.1-py3-none-any.whl", hash = "sha256:77cfba1d6e91b9bc3d36dc7dc74a9bb80be351948db5f880f2562a0cbf20b6c5"},
+]
+django-environ = [
+    {file = "django-environ-0.4.5.tar.gz", hash = "sha256:6c9d87660142608f63ec7d5ce5564c49b603ea8ff25da595fd6098f6dc82afde"},
+    {file = "django_environ-0.4.5-py2.py3-none-any.whl", hash = "sha256:c57b3c11ec1f319d9474e3e5a79134f40174b17c7cc024bbb2fad84646b120c4"},
 ]
 django-extensions = [
     {file = "django-extensions-2.2.5.tar.gz", hash = "sha256:b58320d3fe3d6ae7d1d8e38959713fa92272f4921e662d689058d942a5b444f7"},
@@ -2420,9 +2412,6 @@ pytest-testmon = [
 pytest-timeout = [
     {file = "pytest-timeout-1.3.3.tar.gz", hash = "sha256:4a30ba76837a32c7b7cd5c84ee9933fde4b9022b0cd20ea7d4a577c2a1649fb1"},
     {file = "pytest_timeout-1.3.3-py2.py3-none-any.whl", hash = "sha256:d49f618c6448c14168773b6cdda022764c63ea80d42274e3156787e8088d04c6"},
-]
-python-decouple = [
-    {file = "python-decouple-3.3.tar.gz", hash = "sha256:55c546b85b0c47a15a47a4312d451a437f7344a9be3e001660bccd93b637de95"},
 ]
 pytz = [
     {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,8 @@ django-csp = "^3.5"
 django-health-check = "^3.11"
 django-http-referrer-policy = "^1.0"
 django-feature-policy = "^3.1"
-python-decouple = "^3.3"
 dump-env = "^1.1"
 bcrypt = "^3.1"
-dj-database-url = "^0.5.0"
 typing-extensions = "^3.7.4"
 waitress = "^1.3.1"
 whitenoise = {extras = ["brotli"], version = "^5.0"}
@@ -35,6 +33,7 @@ sentry-sdk = "^0.13.5"
 django-staff-sso-client = {git = "https://github.com/uktrade/django-staff-sso-client.git", rev = "c9e58f82003433cad5a870caccd12fed079326c9"}
 django-admin-oauth2 = "^1.2.0"
 django-admin-ip-restrictor = "^2.1.1"
+django-environ = "^0.4.5"
 
 
 [tool.poetry.dev-dependencies]

--- a/server/settings/components/__init__.py
+++ b/server/settings/components/__init__.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import PurePath
 
 import environ
@@ -10,4 +9,4 @@ BASE_DIR = PurePath(__file__).parent.parent.parent.parent
 # Loading `.env` files
 # See docs: https://github.com/joke2k/django-environ
 env = environ.Env()
-environ.Env.read_env(os.path.join(BASE_DIR, "config", ".env"))
+environ.Env.read_env(BASE_DIR.joinpath("config", ".env").as_posix())

--- a/server/settings/components/__init__.py
+++ b/server/settings/components/__init__.py
@@ -1,11 +1,13 @@
+import os
 from pathlib import PurePath
 
-from decouple import AutoConfig
+import environ
 
 # Build paths inside the project like this: BASE_DIR.joinpath('some')
 # `pathlib` is better than writing: dirname(dirname(dirname(__file__)))
 BASE_DIR = PurePath(__file__).parent.parent.parent.parent
 
 # Loading `.env` files
-# See docs: https://gitlab.com/mkleehammer/autoconfig
-config = AutoConfig(search_path=BASE_DIR.joinpath("config"))
+# See docs: https://github.com/joke2k/django-environ
+env = environ.Env()
+environ.Env.read_env(os.path.join(BASE_DIR, "config", ".env"))

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -11,17 +11,15 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 from typing import Dict, List, Tuple, Union
 
-from decouple import Csv
-from dj_database_url import parse as db_url  # noqa: WPS347
 from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as ugt
 
-from server.settings.components import BASE_DIR, config
+from server.settings.components import BASE_DIR, env
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
-SECRET_KEY = config("DJANGO_SECRET_KEY")
+SECRET_KEY = env("DJANGO_SECRET_KEY")
 
 # Application definition:
 
@@ -92,7 +90,7 @@ WSGI_APPLICATION = "server.wsgi.application"
 
 
 DATABASES = {
-    "default": config("DATABASE_URL", cast=db_url,),
+    "default": env.db(),
 }
 
 # Internationalization
@@ -198,9 +196,9 @@ FEATURE_POLICY: Dict[str, Union[str, List[str]]] = {}  # noqa: TAE002
 EMAIL_TIMEOUT = 5
 
 # Authbroker
-AUTHBROKER_URL = config("AUTHBROKER_URL")
-AUTHBROKER_CLIENT_ID = config("AUTHBROKER_CLIENT_ID")
-AUTHBROKER_CLIENT_SECRET = config("AUTHBROKER_CLIENT_SECRET")
+AUTHBROKER_URL = env.url("AUTHBROKER_URL").geturl()
+AUTHBROKER_CLIENT_ID = env.str("AUTHBROKER_CLIENT_ID")
+AUTHBROKER_CLIENT_SECRET = env.str("AUTHBROKER_CLIENT_SECRET")
 
 LOGIN_URL = reverse_lazy("authbroker_client:login")
 LOGIN_REDIRECT_URL = reverse_lazy("admin:index")
@@ -211,4 +209,4 @@ INTERNAL_IPS = ("127.0.0.1",)
 RESTRICT_ADMIN = True
 TRUST_PRIVATE_IP = True
 # comma-separated list of IPs expected
-ALLOWED_ADMIN_IPS = config("ALLOWED_ADMIN_IPS", default="127.0.0.1,::1", cast=Csv())
+ALLOWED_ADMIN_IPS = env.list("ALLOWED_ADMIN_IPS", default=["127.0.0.1", "::1"])

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -19,7 +19,7 @@ from server.settings.components import BASE_DIR, env
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
-SECRET_KEY = env("DJANGO_SECRET_KEY")
+SECRET_KEY = env.str("DJANGO_SECRET_KEY")
 
 # Application definition:
 

--- a/server/settings/environments/development.py
+++ b/server/settings/environments/development.py
@@ -7,7 +7,7 @@ SECURITY WARNING: don't run with debug turned on in production!
 import logging
 from typing import List
 
-from server.settings.components import config
+from server.settings.components import env
 from server.settings.components.common import INSTALLED_APPS, MIDDLEWARE
 from server.settings.components.logging import LOGGING
 
@@ -15,7 +15,7 @@ from server.settings.components.logging import LOGGING
 
 DEBUG = True
 
-ALLOWED_HOSTS = [config("DOMAIN_NAME"), "localhost", "127.0.0.1", "[::1]"]
+ALLOWED_HOSTS = [env.str("DOMAIN_NAME"), "localhost", "127.0.0.1", "[::1]"]
 
 
 # Installed apps for developement only:

--- a/server/settings/environments/production.py
+++ b/server/settings/environments/production.py
@@ -7,7 +7,7 @@ values are overridden.
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from server.settings.components import config
+from server.settings.components import env
 
 # Production flags:
 # https://docs.djangoproject.com/en/2.2/howto/deployment/
@@ -16,7 +16,7 @@ DEBUG = False
 
 ALLOWED_HOSTS = [
     # TODO: check production hosts
-    config("DOMAIN_NAME")
+    env.str("DOMAIN_NAME")
 ]
 
 
@@ -49,7 +49,7 @@ SECURE_SSL_REDIRECT = True
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
-SENTRY_DSN = config("SENTRY_DSN", default=None)
+SENTRY_DSN = env.str("SENTRY_DSN", default=None)
 
 if SENTRY_DSN is not None:
     sentry_sdk.hub.init(


### PR DESCRIPTION
`django-environ` is in use on other DIT projects, and seems to have a slightly nicer API and some djangos-specific convenience methods.