### PR TITLE
Add AuditLogMiddleware

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,9 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Configure poetry
-          command: poetry config virtualenvs.in-project true
-
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "poetry.lock" }}
+            - v3-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Install dependencies
@@ -52,8 +48,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ./.venv
-          key: v2-dependencies-{{ checksum "poetry.lock" }}
+            - ~/.cache/pypoetry/virtualenvs
+          key: v3-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Run flake8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,13 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Configure poetry
+          command: poetry config virtualenvs.in-project true
+
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "poetry.lock" }}
+            - v2-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Install dependencies
@@ -48,8 +52,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.cache/pypoetry/virtualenvs
-          key: v3-dependencies-{{ checksum "poetry.lock" }}
+            - ./.venv
+          key: v2-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Run flake8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
 
       - run:
           name: Check migrations are backwards-compatible
-          command: poetry run ./manage.py lintmigrations --exclude-apps=axes
+          command: poetry run ./manage.py lintmigrations --exclude-apps axes sites
 
       - run:
           name: Code quality check

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 .PHONY: test
 
 lint-migrations:
-> poetry run ./manage.py lintmigrations --exclude-apps=axes
+> poetry run ./manage.py lintmigrations --exclude-apps axes sites
 .PHONY: lint-migrations
 
 flake8:

--- a/docker/ci.sh
+++ b/docker/ci.sh
@@ -44,7 +44,7 @@ run_ci () {
   python manage.py makemigrations --dry-run --check
 
   # Check that all migrations are backwards compatible:
-  python manage.py lintmigrations --exclude-apps=axes
+  python manage.py lintmigrations --exclude-apps axes sites
 
   # Running code-quality check:
   xenon --max-absolute A --max-modules A --max-average A server

--- a/poetry.lock
+++ b/poetry.lock
@@ -275,6 +275,14 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 category = "main"
+description = "Generate generic activity streams from the actions on your site. Users can follow any actors' activities for personalized streams."
+name = "django-activity-stream"
+optional = false
+python-versions = "*"
+version = "0.8.0"
+
+[[package]]
+category = "main"
 description = "A Django middleware to restrict incoming IPs to admin panel"
 name = "django-admin-ip-restrictor"
 optional = false
@@ -470,6 +478,7 @@ test = ["pytest", "pytest-cov", "pytest-sugar", "flake8 (3.0.4)", "requests-mock
 reference = "c9e58f82003433cad5a870caccd12fed079326c9"
 type = "git"
 url = "https://github.com/uktrade/django-staff-sso-client.git"
+
 [[package]]
 category = "main"
 description = "Structured Logging for Django"
@@ -1931,7 +1940,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "4a7c4190b1d30b955ab906078581b15d3864e09fe7014b00fc77dbcc7226c4f5"
+content-hash = "d0c96151b7e90ecc1e3f9c3a95adc7dc8c1f44ad140087236593b3123badde3f"
 python-versions = "3.7.*"
 
 [metadata.files]
@@ -2138,6 +2147,9 @@ decorator = [
 django = [
     {file = "Django-2.2.10-py3-none-any.whl", hash = "sha256:9a4635813e2d498a3c01b10c701fe4a515d76dd290aaa792ccb65ca4ccb6b038"},
     {file = "Django-2.2.10.tar.gz", hash = "sha256:1226168be1b1c7efd0e66ee79b0e0b58b2caa7ed87717909cd8a57bb13a7079a"},
+]
+django-activity-stream = [
+    {file = "django-activity-stream-0.8.0.tar.gz", hash = "sha256:ef07f7242f25dbf6e198b377632a72fdd0c06ce3cd1097c394d9b7052c943b4e"},
 ]
 django-admin-ip-restrictor = [
     {file = "django-admin-ip-restrictor-2.1.1.tar.gz", hash = "sha256:d7a6acc01c9d10723b79953666ff09fb96edd97e7a9960a8a4f1d302604a37e3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -429,6 +429,26 @@ python-versions = "*"
 version = "2.1.0"
 
 [[package]]
+category = "main"
+description = "JSONField for django models"
+name = "django-jsonfield"
+optional = false
+python-versions = "*"
+version = "1.4.0"
+
+[package.dependencies]
+Django = ">=1.11"
+six = "*"
+
+[[package]]
+category = "main"
+description = "Compatability layer between django-jsonfield and Django's native JSONField"
+name = "django-jsonfield-compat"
+optional = false
+python-versions = "*"
+version = "0.4.4"
+
+[[package]]
 category = "dev"
 description = "Detect backward incompatible migrations for your django project"
 name = "django-migration-linter"
@@ -1940,7 +1960,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "d0c96151b7e90ecc1e3f9c3a95adc7dc8c1f44ad140087236593b3123badde3f"
+content-hash = "12e89741bd2095050aaa16d0450cc221ac718f426f2db0c2a46727224ebcd722"
 python-versions = "3.7.*"
 
 [metadata.files]
@@ -2200,6 +2220,14 @@ django-http-referrer-policy = [
 ]
 django-ipware = [
     {file = "django-ipware-2.1.0.tar.gz", hash = "sha256:a7c7a8fd019dbdc9c357e6e582f65034e897572fc79a7e467674efa8aef9d00b"},
+]
+django-jsonfield = [
+    {file = "django-jsonfield-1.4.0.tar.gz", hash = "sha256:9b3dac9f7352a6d37e9cfe0126c5b58ac7abf1cb20c0da294a00269a725223f1"},
+    {file = "django_jsonfield-1.4.0-py2.py3-none-any.whl", hash = "sha256:7bdd0ea75ad842b9e33decdf343398c91fbb7bd664fde0648ef83e78b0453b6e"},
+]
+django-jsonfield-compat = [
+    {file = "django-jsonfield-compat-0.4.4.tar.gz", hash = "sha256:0182d2e9db886abc2bf30958e4953f72b6f0e20336524755641bc3968899cd5b"},
+    {file = "django_jsonfield_compat-0.4.4-py2.py3-none-any.whl", hash = "sha256:e2b1cd7dfef7633c8befb9c85fa764d344377512c8fdaf65ded4827392410a1d"},
 ]
 django-migration-linter = [
     {file = "django-migration-linter-1.5.0.tar.gz", hash = "sha256:c344ba3eaef2a1fe3f481b05711dc18ef81f800f03be5aa84a18edeccbe7c2de"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ requests_hawk = "^1.0.0"
 furl = "^2.1.0"
 django-tqdm = "^1.0.0"
 django-filter = "^2.2.0"
+django-activity-stream = "^0.8.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ furl = "^2.1.0"
 django-tqdm = "^1.0.0"
 django-filter = "^2.2.0"
 django-activity-stream = "^0.8.0"
+django-jsonfield = "^1.4.0"
+django-jsonfield-compat = "^0.4.4"
 
 
 [tool.poetry.dev-dependencies]

--- a/server/apps/main/apps.py
+++ b/server/apps/main/apps.py
@@ -6,3 +6,9 @@ class MainConfig(AppConfig):
 
     def ready(self):
         from server.apps.main import signals  # noqa: F401
+        from actstream import registry  # noqa: F401
+        from django.contrib.auth.models import User
+
+        registry.register(self.get_model("Consent"))
+        registry.register(self.get_model("LegalBasis"))
+        registry.register(User)

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from typing import Callable, Dict, List, Optional
 
@@ -8,6 +9,8 @@ from django.http import HttpRequest, HttpResponse
 from typing_extensions import final
 
 from server.apps.main.models import Consent, LegalBasis
+
+logger = logging.getLogger(__name__)
 
 
 class AuditLogMiddleware:
@@ -65,13 +68,13 @@ class AuditLogMiddleware:
                     action_kwargs["target"] = Consent.objects.get(pk=pk)
 
                     action.send(**action_kwargs)
-                    print(f"Action sent: {action_kwargs}")
+                    logger.info(f"Action sent: {action_kwargs}")
 
             if kwargs["action"] == "post_clear":
                 action_kwargs["verb"] = "cleared consents"
 
                 action.send(**action_kwargs)
-                print(f"Action sent: {action_kwargs}")
+                logger.info(f"Action sent: {action_kwargs}")
 
         return inner
 
@@ -86,7 +89,7 @@ class AuditLogMiddleware:
             }
 
             action.send(**action_kwargs)
-            print(f"Action sent: {action_kwargs}")
+            logger.info(f"Action sent: {action_kwargs}")
 
         return inner
 
@@ -101,7 +104,7 @@ class AuditLogMiddleware:
             }
 
             action.send(**action_kwargs)
-            print(f"Action sent: {action_kwargs}")
+            logger.info(f"Action sent: {action_kwargs}")
 
         return inner
 

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -56,7 +56,6 @@ class AuditLogMiddleware:
         def inner(sender: Model, **kwargs) -> None:
             action_kwargs = {
                 "sender": request.user,
-                "action_object": kwargs["instance"],
                 "remote_addr": self.get_remote_addr(request),
             }
 
@@ -65,13 +64,15 @@ class AuditLogMiddleware:
                     action_kwargs["verb"] = (
                         "added" if kwargs["action"] == "post_add" else "removed"
                     )
-                    action_kwargs["target"] = Consent.objects.get(pk=pk)
+                    action_kwargs["action_object"] = Consent.objects.get(pk=pk)
+                    action_kwargs["target"] = kwargs["instance"]
 
                     action.send(**action_kwargs)
                     logger.info(f"Action sent: {action_kwargs}")
 
             if kwargs["action"] == "post_clear":
                 action_kwargs["verb"] = "cleared consents"
+                action_kwargs["action_object"] = kwargs["instance"]
 
                 action.send(**action_kwargs)
                 logger.info(f"Action sent: {action_kwargs}")

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -68,7 +68,6 @@ class AuditLogMiddleware:
                     action_kwargs["target"] = kwargs["instance"]
 
                     action.send(**action_kwargs)
-                    print(f"Action sent: {action_kwargs}")
                     logger.info(f"Action sent: {action_kwargs}")
 
             if kwargs["action"] == "post_clear":

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -43,7 +43,7 @@ class AuditLogMiddleware:
                 (
                     post_save,
                     LegalBasis,
-                    self.make_save_delete_signal_receiver(request, "saved"),
+                    self.make_save_delete_signal_receiver(request, "updated"),
                 ),
                 (
                     post_delete,

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -64,10 +64,11 @@ class AuditLogMiddleware:
                     action_kwargs["verb"] = (
                         "added" if kwargs["action"] == "post_add" else "removed"
                     )
-                    action_kwargs["action_object"] = Consent.objects.get(pk=pk)
+                    action_kwargs["action_object"] = Consent.objects.get(pk=pk)  # type: ignore
                     action_kwargs["target"] = kwargs["instance"]
 
                     action.send(**action_kwargs)
+                    print(f"Action sent: {action_kwargs}")
                     logger.info(f"Action sent: {action_kwargs}")
 
             if kwargs["action"] == "post_clear":

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -6,7 +6,6 @@ from actstream import action
 from django.db.models import Model
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.http import HttpRequest, HttpResponse
-from typing_extensions import final
 
 from server.apps.main.models import Consent, LegalBasis
 
@@ -31,7 +30,6 @@ class AuditLogMiddleware:
 
         return response
 
-    @final
     def get_signal_calls(self, request: HttpRequest) -> List[Dict]:
         m2m_through = LegalBasis.consents.through
 
@@ -51,7 +49,6 @@ class AuditLogMiddleware:
             ]
         ]
 
-    @final
     def make_m2m_signal_receiver(self, request: HttpRequest) -> Callable:
         def inner(sender: Model, **kwargs) -> None:
             action_kwargs = {
@@ -74,7 +71,6 @@ class AuditLogMiddleware:
 
         return inner
 
-    @final
     def handle_m2m_post_add_remove_actions(
         self, instance: Model, action_kwargs: Dict, action_name: str, pk_set: List
     ) -> None:
@@ -86,7 +82,6 @@ class AuditLogMiddleware:
             action.send(**action_kwargs)
             logger.info(f"Action sent: {action_kwargs}")
 
-    @final
     def handle_m2m_post_clear_action(
         self, instance: Model, action_kwargs: Dict
     ) -> None:
@@ -96,7 +91,6 @@ class AuditLogMiddleware:
         action.send(**action_kwargs)
         logger.info(f"Action sent: {action_kwargs}")
 
-    @final
     def make_save_signal_receiver(self, request: HttpRequest) -> Callable:
         def inner(sender: Model, **kwargs) -> None:
             action_kwargs = {
@@ -111,7 +105,6 @@ class AuditLogMiddleware:
 
         return inner
 
-    @final
     def make_delete_signal_receiver(self, request: HttpRequest) -> Callable:
         def inner(sender: Model, **kwargs) -> None:
             action_kwargs = {
@@ -126,7 +119,6 @@ class AuditLogMiddleware:
 
         return inner
 
-    @final
     def get_remote_addr(self, request: HttpRequest) -> Optional[str]:
         remote_addr = request.META.get("HTTP_X_FORWARDED_FOR")
         if remote_addr is not None:

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -1,0 +1,103 @@
+# from functools import partial
+
+import uuid
+
+from actstream import action
+from django.db.models.signals import m2m_changed, post_delete, post_save
+
+from server.apps.main.models import Consent, LegalBasis
+
+
+class AuditLogMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+
+        signal_calls = self.get_signal_calls(request)
+
+        for call in signal_calls:
+            call["signal"].connect(weak=False, **call["kwargs"])
+
+        response = self.get_response(request)
+
+        for call in signal_calls:
+            call["signal"].disconnect(**call["kwargs"])
+
+        return response
+
+    def get_signal_calls(self, request):
+        return [
+            {
+                "signal": signal,
+                "kwargs": {
+                    "sender": sender,
+                    "receiver": receiver,
+                    "dispatch_uid": uuid.uuid4(),
+                },
+            }
+            for signal, sender, receiver in [
+                (
+                    post_save,
+                    LegalBasis,
+                    self.make_save_delete_signal_receiver(request, "saved"),
+                ),
+                (
+                    post_delete,
+                    LegalBasis,
+                    self.make_save_delete_signal_receiver(request, "deleted"),
+                ),
+                (
+                    m2m_changed,
+                    LegalBasis.consents.through,
+                    self.make_m2m_changed_signal_receiver(request),
+                ),
+            ]
+        ]
+
+    def make_m2m_changed_signal_receiver(self, request):
+        def inner(sender, **kwargs):
+            action_kwargs = {
+                "sender": request.user,
+                "action_object": kwargs["instance"],
+                "remote_addr": self.get_remote_addr(request),
+            }
+
+            if kwargs["action"] in ["post_add", "post_remove"]:
+                for pk in kwargs["pk_set"]:
+                    action_kwargs["verb"] = (
+                        "added" if kwargs["action"] == "post_add" else "removed"
+                    )
+                    action_kwargs["target"] = Consent.objects.get(pk=pk)
+
+                    action.send(**action_kwargs)
+                    print(f"Action sent: {action_kwargs}")
+
+            if kwargs["action"] == "post_clear":
+                action_kwargs["verb"] = "cleared consents"
+
+                action.send(**action_kwargs)
+                print(f"Action sent: {action_kwargs}")
+
+        return inner
+
+    def make_save_delete_signal_receiver(self, request, verb):
+        def inner(sender, **kwargs):
+            action_kwargs = {
+                "sender": request.user,
+                "action_object": kwargs["instance"],
+                "verb": "created" if kwargs.get("created") is True else verb,
+                "remote_addr": self.get_remote_addr(request),
+            }
+
+            action.send(**action_kwargs)
+            print(f"Action sent: {action_kwargs}")
+
+        return inner
+
+    def get_remote_addr(self, request):
+        return (
+            request.META.get("HTTP_X_FORWARDED_FOR").split(",")[0]
+            if request.META.get("HTTP_X_FORWARDED_FOR")
+            else request.META.get("REMOTE_ADDR")
+        )

--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -4,17 +4,17 @@ from typing import Callable, Dict, List, Optional
 from actstream import action
 from django.db.models import Model
 from django.db.models.signals import m2m_changed, post_delete, post_save
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
 from typing_extensions import final
 
 from server.apps.main.models import Consent, LegalBasis
 
 
 class AuditLogMiddleware:
-    def __init__(self, get_response):
+    def __init__(self, get_response) -> None:
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request) -> HttpResponse:
 
         signal_calls = self.get_signal_calls(request)
 

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -40,6 +40,7 @@ INSTALLED_APPS: Tuple[str, ...] = (
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     # django-admin:
     "django.contrib.admin",
     "django.contrib.admindocs",
@@ -56,6 +57,8 @@ INSTALLED_APPS: Tuple[str, ...] = (
     "django_http_referrer_policy",
     "hawkrest",
     "authbroker_client",
+    # Activity Stream
+    "actstream",
 )
 
 MIDDLEWARE: Tuple[str, ...] = (
@@ -72,6 +75,7 @@ MIDDLEWARE: Tuple[str, ...] = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "server.apps.main.middleware.AuditLogMiddleware",
     # Axes:
     "axes.middleware.AxesMiddleware",
     # hawk rest
@@ -95,6 +99,9 @@ WSGI_APPLICATION = "server.wsgi.application"
 DATABASES = {
     "default": env.db(),
 }
+
+# Django Sites
+SITE_ID = 1
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/
@@ -215,6 +222,11 @@ TRUST_PRIVATE_IP = True
 ALLOWED_ADMIN_IPS = env.list("ALLOWED_ADMIN_IPS", default=["127.0.0.1", "::1"])
 
 # Activity Stream Credentials
-ACTIVITY_STREAM_URL = env('ACTIVITY_STREAM_URL', cast=furl)
-ACTIVITY_STREAM_KEY = env.str('ACTIVITY_STREAM_KEY')
-ACTIVITY_STREAM_ID = env.str('ACTIVITY_STREAM_ID')
+ACTIVITY_STREAM_URL = env("ACTIVITY_STREAM_URL", cast=furl)
+ACTIVITY_STREAM_KEY = env.str("ACTIVITY_STREAM_KEY")
+ACTIVITY_STREAM_ID = env.str("ACTIVITY_STREAM_ID")
+
+# This app's Activity Stream config
+ACTSTREAM_SETTINGS = {
+    "USE_JSONFIELD": True,
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ default_section = FIRSTPARTY
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-virtual_env = ~/.venv
 
 
 [darglint]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ default_section = FIRSTPARTY
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+virtual_env = ~/.venv
 
 
 [darglint]

--- a/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
+++ b/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
@@ -134,13 +134,14 @@ class TestAuditLogMiddleWare:
             "sender": request.user,
             "target": instance,
             "remote_addr": "127.0.0.1",
+            "verb": "added",
         }
 
         action.send.assert_has_calls(
             [
-                call(verb="added", action_object=Consent.objects.get(pk=1), **kwargs),
-                call(verb="added", action_object=Consent.objects.get(pk=2), **kwargs),
-                call(verb="added", action_object=Consent.objects.get(pk=3), **kwargs),
+                call(action_object=Consent.objects.get(pk=1), **kwargs),
+                call(action_object=Consent.objects.get(pk=2), **kwargs),
+                call(action_object=Consent.objects.get(pk=3), **kwargs),
             ]
         )
 
@@ -161,13 +162,14 @@ class TestAuditLogMiddleWare:
             "sender": request.user,
             "target": instance,
             "remote_addr": "127.0.0.1",
+            "verb": "removed",
         }
 
         action.send.assert_has_calls(
             [
-                call(verb="removed", action_object=Consent.objects.get(pk=1), **kwargs),
-                call(verb="removed", action_object=Consent.objects.get(pk=2), **kwargs),
-                call(verb="removed", action_object=Consent.objects.get(pk=3), **kwargs),
+                call(action_object=Consent.objects.get(pk=1), **kwargs),
+                call(action_object=Consent.objects.get(pk=2), **kwargs),
+                call(action_object=Consent.objects.get(pk=3), **kwargs),
             ]
         )
 
@@ -183,13 +185,12 @@ class TestAuditLogMiddleWare:
             Mock(), instance=instance, action="post_clear"
         )
 
-        kwargs = {
-            "sender": request.user,
-            "action_object": instance,
-            "remote_addr": "127.0.0.1",
-        }
-
-        action.send.assert_called_once_with(verb="cleared consents", **kwargs)
+        action.send.assert_called_once_with(
+            sender=request.user,
+            action_object=instance,
+            remote_addr="127.0.0.1",
+            verb="cleared consents",
+        )
 
     def test_get_remote_addr_x_forwarded_for(self):
         middleware = AuditLogMiddleware(self.get_response)

--- a/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
+++ b/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
@@ -132,15 +132,15 @@ class TestAuditLogMiddleWare:
 
         kwargs = {
             "sender": request.user,
-            "action_object": instance,
+            "target": instance,
             "remote_addr": "127.0.0.1",
         }
 
         action.send.assert_has_calls(
             [
-                call(verb="added", target=Consent.objects.get(pk=1), **kwargs),
-                call(verb="added", target=Consent.objects.get(pk=2), **kwargs),
-                call(verb="added", target=Consent.objects.get(pk=3), **kwargs),
+                call(verb="added", action_object=Consent.objects.get(pk=1), **kwargs),
+                call(verb="added", action_object=Consent.objects.get(pk=2), **kwargs),
+                call(verb="added", action_object=Consent.objects.get(pk=3), **kwargs),
             ]
         )
 
@@ -159,15 +159,15 @@ class TestAuditLogMiddleWare:
 
         kwargs = {
             "sender": request.user,
-            "action_object": instance,
+            "target": instance,
             "remote_addr": "127.0.0.1",
         }
 
         action.send.assert_has_calls(
             [
-                call(verb="removed", target=Consent.objects.get(pk=1), **kwargs),
-                call(verb="removed", target=Consent.objects.get(pk=2), **kwargs),
-                call(verb="removed", target=Consent.objects.get(pk=3), **kwargs),
+                call(verb="removed", action_object=Consent.objects.get(pk=1), **kwargs),
+                call(verb="removed", action_object=Consent.objects.get(pk=2), **kwargs),
+                call(verb="removed", action_object=Consent.objects.get(pk=3), **kwargs),
             ]
         )
 

--- a/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
+++ b/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
@@ -1,0 +1,141 @@
+import uuid
+from unittest.mock import Mock, patch
+
+import pytest
+from django.db.models.signals import m2m_changed, post_delete, post_save
+
+from server.apps.main.middleware import AuditLogMiddleware
+from server.apps.main.models import LegalBasis
+
+
+class TestAuditLogMiddleWare:
+    pytestmark = pytest.mark.django_db
+
+    @classmethod
+    def setup_class(cls):
+        cls.get_response = Mock()
+
+    @classmethod
+    def is_valid_uuid(cls, v):
+        try:
+            uuid.UUID(str(v))
+            return True
+        except ValueError:
+            return False
+
+    def test_init(self):
+        middleware = AuditLogMiddleware(self.get_response)
+        assert middleware.get_response == self.get_response
+
+    @patch.object(AuditLogMiddleware, "make_m2m_signal_receiver")
+    @patch.object(AuditLogMiddleware, "make_save_signal_receiver")
+    @patch.object(AuditLogMiddleware, "make_delete_signal_receiver")
+    def test_get_signal_calls(
+        self,
+        make_delete_signal_receiver,
+        make_save_signal_receiver,
+        make_m2m_signal_receiver,
+    ):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        request = Mock()
+        calls = middleware.get_signal_calls(request)
+
+        assert calls[0]["signal"] == post_save
+        assert calls[0]["kwargs"]["sender"] == LegalBasis
+        assert callable(calls[0]["kwargs"]["receiver"])
+        assert self.is_valid_uuid(calls[0]["kwargs"]["dispatch_uid"])
+
+        assert calls[1]["signal"] == post_delete
+        assert calls[1]["kwargs"]["sender"] == LegalBasis
+        assert callable(calls[1]["kwargs"]["receiver"])
+        assert self.is_valid_uuid(calls[1]["kwargs"]["dispatch_uid"])
+
+        assert calls[2]["signal"] == m2m_changed
+        assert calls[2]["kwargs"]["sender"] == LegalBasis.consents.through
+        assert callable(calls[2]["kwargs"]["receiver"])
+        assert self.is_valid_uuid(calls[2]["kwargs"]["dispatch_uid"])
+
+        make_delete_signal_receiver.assert_called_once_with(request)
+        make_save_signal_receiver.called_once_with(request, "updated")
+        make_m2m_signal_receiver.assert_called_once_with(request)
+
+    @patch.object(AuditLogMiddleware, "get_remote_addr")
+    @patch("server.apps.main.middleware.action")
+    def test_make_save_signal_receiver_when_created(self, action, get_remote_addr):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        get_remote_addr.return_value = "127.0.0.1"
+        request = Mock()
+        instance = Mock()
+
+        middleware.make_save_signal_receiver(request)(
+            Mock(), instance=instance, created=True
+        )
+
+        action.send.assert_called_once_with(
+            sender=request.user,
+            action_object=instance,
+            verb="created",
+            remote_addr="127.0.0.1",
+        )
+
+    @patch.object(AuditLogMiddleware, "get_remote_addr")
+    @patch("server.apps.main.middleware.action")
+    def test_make_save_signal_receiver_when_updated(self, action, get_remote_addr):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        get_remote_addr.return_value = "127.0.0.1"
+        instance = Mock()
+        request = Mock()
+
+        middleware.make_save_signal_receiver(request)(
+            Mock(), instance=instance, created=False
+        )
+
+        action.send.assert_called_once_with(
+            sender=request.user,
+            action_object=instance,
+            verb="updated",
+            remote_addr="127.0.0.1",
+        )
+
+    @patch.object(AuditLogMiddleware, "get_remote_addr")
+    @patch("server.apps.main.middleware.action")
+    def test_make_delete_signal_receiver(self, action, get_remote_addr):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        get_remote_addr.return_value = "127.0.0.1"
+        instance = Mock()
+        request = Mock()
+        middleware.make_delete_signal_receiver(request)(Mock(), instance=instance)
+
+        action.send.assert_called_once_with(
+            sender=request.user,
+            action_object=instance,
+            verb="deleted",
+            remote_addr="127.0.0.1",
+        )
+
+    def test_get_remote_addr_x_forwarded_for(self):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        assert (
+            middleware.get_remote_addr(
+                Mock(
+                    META={
+                        "HTTP_X_FORWARDED_FOR": "172.16.0.1, 192.168.0.1, 127.0.0.1",
+                        "REMOTE_ADDR": "192.168.0.1",
+                    }
+                )
+            )
+            == "172.16.0.1"
+        )
+
+    def test_get_remote_addr(self):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        assert (
+            middleware.get_remote_addr(Mock(META={"REMOTE_ADDR": "192.168.0.1",}))
+            == "192.168.0.1"
+        )

--- a/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
+++ b/tests/test_apps/test_main/test_middleware/test_audit_log_middleware.py
@@ -117,23 +117,87 @@ class TestAuditLogMiddleWare:
             remote_addr="127.0.0.1",
         )
 
-    @patch("server.apps.main.middleware.Consent")
+    @patch.object(AuditLogMiddleware, "handle_m2m_post_add_remove_actions")
     @patch.object(AuditLogMiddleware, "get_remote_addr")
-    @patch("server.apps.main.middleware.action")
-    def test_m2m_signal_receiver_when_added(self, action, get_remote_addr, Consent):
+    def test_m2m_signal_receiver_with_post_add(
+        self, get_remote_addr, handle_m2m_post_add_remove_actions
+    ):
         middleware = AuditLogMiddleware(self.get_response)
 
         get_remote_addr.return_value = "127.0.0.1"
         instance = Mock()
         request = Mock()
+
+        action_kwargs = {"sender": request.user, "remote_addr": "127.0.0.1"}
+
         middleware.make_m2m_signal_receiver(request)(
             Mock(), instance=instance, action="post_add", pk_set=[1, 2, 3]
         )
+        handle_m2m_post_add_remove_actions.assert_called_once_with(
+            instance=instance,
+            action_kwargs=action_kwargs,
+            action_name="post_add",
+            pk_set=[1, 2, 3],
+        )
+
+    @patch.object(AuditLogMiddleware, "handle_m2m_post_add_remove_actions")
+    @patch.object(AuditLogMiddleware, "get_remote_addr")
+    def test_m2m_signal_receiver_with_post_remove(
+        self, get_remote_addr, handle_m2m_post_add_remove_actions
+    ):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        get_remote_addr.return_value = "127.0.0.1"
+        instance = Mock()
+        request = Mock()
+
+        action_kwargs = {"sender": request.user, "remote_addr": "127.0.0.1"}
+
+        middleware.make_m2m_signal_receiver(request)(
+            Mock(), instance=instance, action="post_remove", pk_set=[3, 4, 5]
+        )
+        handle_m2m_post_add_remove_actions.assert_called_once_with(
+            instance=instance,
+            action_kwargs=action_kwargs,
+            action_name="post_remove",
+            pk_set=[3, 4, 5],
+        )
+
+    @patch.object(AuditLogMiddleware, "handle_m2m_post_clear_action")
+    @patch.object(AuditLogMiddleware, "get_remote_addr")
+    def test_m2m_signal_receiver_with_post_clear(
+        self, get_remote_addr, handle_m2m_post_clear_action,
+    ):
+        middleware = AuditLogMiddleware(self.get_response)
+
+        get_remote_addr.return_value = "127.0.0.1"
+        instance = Mock()
+        request = Mock()
+
+        action_kwargs = {"sender": request.user, "remote_addr": "127.0.0.1"}
+
+        middleware.make_m2m_signal_receiver(request)(
+            Mock(), instance=instance, action="post_clear"
+        )
+        handle_m2m_post_clear_action.assert_called_once_with(
+            instance=instance, action_kwargs=action_kwargs,
+        )
+
+    @patch("server.apps.main.middleware.Consent")
+    @patch("server.apps.main.middleware.action")
+    def test_handle_m2m_post_add_remove_actions_with_post_add(self, action, Consent):
+        middleware = AuditLogMiddleware(self.get_response)
+        instance = Mock()
+
+        middleware.handle_m2m_post_add_remove_actions(
+            instance=instance,
+            action_kwargs={},
+            action_name="post_add",
+            pk_set=[1, 2, 3],
+        )
 
         kwargs = {
-            "sender": request.user,
             "target": instance,
-            "remote_addr": "127.0.0.1",
             "verb": "added",
         }
 
@@ -146,50 +210,42 @@ class TestAuditLogMiddleWare:
         )
 
     @patch("server.apps.main.middleware.Consent")
-    @patch.object(AuditLogMiddleware, "get_remote_addr")
     @patch("server.apps.main.middleware.action")
-    def test_m2m_signal_receiver_when_deleted(self, action, get_remote_addr, Consent):
+    def test_handle_m2m_post_add_remove_actions_with_post_remove(self, action, Consent):
         middleware = AuditLogMiddleware(self.get_response)
-
-        get_remote_addr.return_value = "127.0.0.1"
         instance = Mock()
-        request = Mock()
-        middleware.make_m2m_signal_receiver(request)(
-            Mock(), instance=instance, action="post_remove", pk_set=[1, 2, 3]
+
+        middleware.handle_m2m_post_add_remove_actions(
+            instance=instance,
+            action_kwargs={},
+            action_name="post_remove",
+            pk_set=[3, 4, 5],
         )
 
         kwargs = {
-            "sender": request.user,
             "target": instance,
-            "remote_addr": "127.0.0.1",
             "verb": "removed",
         }
 
         action.send.assert_has_calls(
             [
-                call(action_object=Consent.objects.get(pk=1), **kwargs),
-                call(action_object=Consent.objects.get(pk=2), **kwargs),
                 call(action_object=Consent.objects.get(pk=3), **kwargs),
+                call(action_object=Consent.objects.get(pk=4), **kwargs),
+                call(action_object=Consent.objects.get(pk=5), **kwargs),
             ]
         )
 
-    @patch.object(AuditLogMiddleware, "get_remote_addr")
     @patch("server.apps.main.middleware.action")
-    def test_m2m_signal_receiver_when_cleared(self, action, get_remote_addr):
+    def test_handle_m2m_post_clear_action(self, action):
         middleware = AuditLogMiddleware(self.get_response)
-
-        get_remote_addr.return_value = "127.0.0.1"
         instance = Mock()
-        request = Mock()
-        middleware.make_m2m_signal_receiver(request)(
-            Mock(), instance=instance, action="post_clear"
+
+        middleware.handle_m2m_post_clear_action(
+            instance=instance, action_kwargs={},
         )
 
         action.send.assert_called_once_with(
-            sender=request.user,
-            action_object=instance,
-            remote_addr="127.0.0.1",
-            verb="cleared consents",
+            verb="cleared consents", action_object=instance
         )
 
     def test_get_remote_addr_x_forwarded_for(self):


### PR DESCRIPTION
Logs all `LegalBasis.save()` operations via [Django Activity Stream](https://django-activity-stream.readthedocs.io/en/latest/) as `actor verb object [target]` constructs, where `actor` is a Django User instance and `object` and optional `target` are `LegalBasis` instances, e.g:

```
<User pk=1> "created" <LegalBasis pk=1>
<User pk=1> "updated" <LegalBasis pk=1>
<User pk=1> "deleted" <LegalBasis pk=1>
<User pk=1> "added" <Consent pk=1> to <LegalBasis pk=1>
<User pk=1> "removed" <Consent pk=1> from <LegalBasis pk=1>
<User pk=1> "cleared consents" of <LegalBasis pk=1>
```