### PR TITLE
Remove django-admin-ip-restrictor

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -283,21 +283,6 @@ version = "0.8.0"
 
 [[package]]
 category = "main"
-description = "A Django middleware to restrict incoming IPs to admin panel"
-name = "django-admin-ip-restrictor"
-optional = false
-python-versions = "*"
-version = "2.1.1"
-
-[package.dependencies]
-django = ">=1.11,<3"
-django-ipware = ">=2,<3"
-
-[package.extras]
-tests = ["coverage (5.0.2)", "pytest (5.3.2)", "pytest-cov (2.8.1)", "pytest-django (3.7.0)", "pytest-sugar (0.9.2)", "tox (3.14.3)"]
-
-[[package]]
-category = "main"
 description = "A django app that replaces the django admin authentication mechanism by deferring to an oauth2 provider"
 name = "django-admin-oauth2"
 optional = false
@@ -529,6 +514,7 @@ test = ["pytest", "pytest-cov", "pytest-sugar", "flake8 (3.0.4)", "requests-mock
 reference = "c9e58f82003433cad5a870caccd12fed079326c9"
 type = "git"
 url = "https://github.com/uktrade/django-staff-sso-client.git"
+
 [[package]]
 category = "main"
 description = "Structured Logging for Django"
@@ -1998,7 +1984,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "4bdfe1dfb5788219ba072eca095f2b79fd033ef97d1410ec21dc07cfa390b1fb"
+content-hash = "7b14651c3c3c8d07a1cbc9400323035b76c6da489f81f487cbf33989a14112b4"
 python-versions = "3.7.*"
 
 [metadata.files]
@@ -2203,9 +2189,6 @@ django = [
 ]
 django-activity-stream = [
     {file = "django-activity-stream-0.8.0.tar.gz", hash = "sha256:ef07f7242f25dbf6e198b377632a72fdd0c06ce3cd1097c394d9b7052c943b4e"},
-]
-django-admin-ip-restrictor = [
-    {file = "django-admin-ip-restrictor-2.1.1.tar.gz", hash = "sha256:d7a6acc01c9d10723b79953666ff09fb96edd97e7a9960a8a4f1d302604a37e3"},
 ]
 django-admin-oauth2 = [
     {file = "django-admin-oauth2-1.2.0.tar.gz", hash = "sha256:f51b2c64e43b756aad087ad56441b3fe1fb40abf6ef306f145c56406bb3cc5b5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ hawkrest = "^1.0.1"
 sentry-sdk = "^0.13.5"
 django-staff-sso-client = {git = "https://github.com/uktrade/django-staff-sso-client.git", rev = "c9e58f82003433cad5a870caccd12fed079326c9"}
 django-admin-oauth2 = "^1.2.0"
-django-admin-ip-restrictor = "^2.1.1"
 django-environ = "^0.4.5"
 elasticsearch-dsl = ">=6.0.0,<7.0.0"
 requests_hawk = "^1.0.0"

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -83,8 +83,6 @@ MIDDLEWARE: Tuple[str, ...] = (
     # Django HTTP Referrer Policy:
     "django_http_referrer_policy.middleware.ReferrerPolicyMiddleware",
     "django_structlog.middlewares.RequestMiddleware",
-    # Admin IP restriction
-    "admin_ip_restrictor.middleware.AdminIPRestrictorMiddleware",
 )
 
 ROOT_URLCONF = "server.urls"
@@ -214,12 +212,6 @@ LOGIN_URL = reverse_lazy("authbroker_client:login")
 LOGIN_REDIRECT_URL = reverse_lazy("admin:index")
 
 INTERNAL_IPS = ("127.0.0.1",)
-
-# Admin IP restriction
-RESTRICT_ADMIN = True
-TRUST_PRIVATE_IP = True
-# comma-separated list of IPs expected
-ALLOWED_ADMIN_IPS = env.list("ALLOWED_ADMIN_IPS", default=["127.0.0.1", "::1"])
 
 # Activity Stream Credentials
 ACTIVITY_STREAM_URL = env("ACTIVITY_STREAM_URL", cast=furl)


### PR DESCRIPTION
Removed in favour of DIT’s nginx ip filter: https://github.com/uktrade/cf-nginx-ip-filter