### PR TITLE
Disallow anonymous read access to API

### DIFF
--- a/server/settings/components/drf.py
+++ b/server/settings/components/drf.py
@@ -10,7 +10,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly",
+        "rest_framework.permissions.DjangoModelPermissions",
     ],
     "ORDERING_PARAM": "sortby",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",


### PR DESCRIPTION
Change DEFAULT_PERMISSION_CLASSES to `DjangoModelPermissions` from
`DjangoModelPermissionsOrAnonReadOnly`