### PR TITLE
Fix manifest.yml for Jenkins pipeline

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,4 @@
 ---
 applications:
-  - buildpacks:
-      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
+  - buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
     stack: cflinuxfs3

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,21 +1,8 @@
 ---
 applications:
-  - name: legal-basis-api-dev
-    services:
+  - services:
       - legal-basis-db
       - legal-basis-redis
-    buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
-    env:
-      DJANGO_ENV: "production"
-      DJANGO_SECRET_KEY: "secret"
-      DOMAIN_NAME: "legal-basis-api-dev.london.cloudapps.digital"
----
-applications:
-  - name: legal-basis-api-staging
-    services:
-      - legal-basis-db
-      - legal-basis-redis
-    routes:
-      - route: legal-basis-api-staging.apps.internal
-      - route: legal-basis-api-staging.london.cloudapps.digital
-    buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
+    buildpacks:
+      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
+    stack: cflinuxfs3

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,5 @@
 ---
 applications:
-  - services:
-      - legal-basis-db
-      - legal-basis-redis
-    buildpacks:
+  - buildpacks:
       - https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
     stack: cflinuxfs3


### PR DESCRIPTION
Now aligns with the general pattern of specifying one application only rather than one per env, and not specifying routes, services or env vars.