### PR TITLE
Add API endpoint for data workspace export

### DIFF
--- a/server/apps/api/views/legal_basis.py
+++ b/server/apps/api/views/legal_basis.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from server.apps.api.serializers import (
     CreateLegalBasisSerializer,
+    LegalBasisDataWorkspaceSerializer,
     LegalBasisSerializer,
     ListOfEmailsSerializer,
 )
@@ -55,12 +56,25 @@ class LegalBasisViewSet(viewsets.ModelViewSet):
 
         if body.is_valid():
             basis_objs = self.paginate_queryset(
-                self.filter_queryset(self.queryset).filter(email__in=body.data["emails"])
+                self.filter_queryset(self.queryset).filter(
+                    email__in=body.data["emails"]
+                )
             )
             serialized = self.get_serializer(instance=basis_objs, many=True)
             return self.get_paginated_response(serialized.data)
 
         return Response(body.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @swagger_auto_schema(
+        method="get",
+        responses={status.HTTP_200_OK: LegalBasisDataWorkspaceSerializer(many=True)},
+    )
+    @action(detail=False, methods=["GET"])
+    def datahub_export(self, request) -> Response:
+        serialized = LegalBasisDataWorkspaceSerializer(
+            instance=self.paginate_queryset(self.queryset), many=True
+        )
+        return self.get_paginated_response(serialized.data)
 
     @swagger_auto_schema(
         request_body=CreateLegalBasisSerializer,

--- a/server/apps/main/migrations/0003_consent_initial_data.py
+++ b/server/apps/main/migrations/0003_consent_initial_data.py
@@ -1,22 +1,23 @@
-
-from django.conf import settings
 from django.db import migrations
 
 from server.apps.main.models import Consent
 
+# Also present in settings.common, but hardcoded here
+# so that migrations don't break if the settings are changed
+CONSENT_TYPES = ("email_marketing", "phone_marketing")
+
 
 class Migration(migrations.Migration):
-
     def create_consent(apps, schema_editor):
-        for name in settings.CONSENT_TYPES:
+        for name in CONSENT_TYPES:
             Consent.objects.get_or_create(name=name)
 
     def delete_consent(apps, schema_editor):
-        for name in settings.CONSENT_TYPES:
+        for name in CONSENT_TYPES:
             Consent.objects.get(name=name).delete()
 
     dependencies = [
-        ('main', '0002_auto_20200218_1028'),
+        ("main", "0002_auto_20200218_1028"),
     ]
 
     operations = [

--- a/server/apps/main/migrations/0003_consent_initial_data.py
+++ b/server/apps/main/migrations/0003_consent_initial_data.py
@@ -1,0 +1,24 @@
+
+from django.conf import settings
+from django.db import migrations
+
+from server.apps.main.models import Consent
+
+
+class Migration(migrations.Migration):
+
+    def create_consent(apps, schema_editor):
+        for name in settings.CONSENT_TYPES:
+            Consent.objects.get_or_create(name=name)
+
+    def delete_consent(apps, schema_editor):
+        for name in settings.CONSENT_TYPES:
+            Consent.objects.get(name=name).delete()
+
+    dependencies = [
+        ('main', '0002_auto_20200218_1028'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_consent, delete_consent),
+    ]

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -274,3 +274,5 @@ ELASTIC_APM = {
 
 # django-allow-cidr
 ALLOWED_CIDR_NETS = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+
+CONSENT_TYPES = ("email_marketing", "phone_marketing")

--- a/tests/test_apps/test_poller/test_managment_commands/test_poll_maxemail.py
+++ b/tests/test_apps/test_poller/test_managment_commands/test_poll_maxemail.py
@@ -14,6 +14,8 @@ class TestMaxemailCommand:
     pytestmark = pytest.mark.django_db
 
     def test_email_consent_creates_if_missing(self):
+        Consent.objects.all().delete()
+
         out = io.StringIO()
         command = poll_maxemail.Command(stdout=out)
         assert Consent.objects.all().count() == 0
@@ -21,38 +23,49 @@ class TestMaxemailCommand:
         assert Consent.objects.all().count() == 1
 
     def test_email_consent_noop_if_exists(self):
+        Consent.objects.all().delete()
+
         out = io.StringIO()
-        mixer.blend(Consent, name='email_marketing')
+        mixer.blend(Consent, name="email_marketing")
         command = poll_maxemail.Command(stdout=out)
         assert Consent.objects.all().count() == 1
         _ = command.email_consent
         assert Consent.objects.all().count() == 1
 
-    @patch('server.apps.poller.management.commands.poll_maxemail.MaxEmail')
+    @patch("server.apps.poller.management.commands.poll_maxemail.MaxEmail")
     def test_get_client(self, mock_client):
         out = io.StringIO()
         command = poll_maxemail.Command(stdout=out)
         _ = command.get_client()
         mock_client.assert_called_once_with(
-            settings.MAXEMAIL_USERNAME,
-            settings.MAXEMAIL_PASSWORD
+            settings.MAXEMAIL_USERNAME, settings.MAXEMAIL_PASSWORD
         )
 
-
     def test_should_update_exists_without_consent(self):
-        mixer.blend(LegalBasis, key=None, phone='',  key_type='email', email='foo@bar.com')
+        mixer.blend(
+            LegalBasis, key=None, phone="", key_type="email", email="foo@bar.com"
+        )
         out = io.StringIO()
         command = poll_maxemail.Command(stdout=out)
-        assert not command._should_update('foo@bar.com')
+        assert not command._should_update("foo@bar.com")
 
     def test_should_update_exists_with_consent(self):
+        Consent.objects.all().delete()
+
         out = io.StringIO()
         command = poll_maxemail.Command(stdout=out)
-        c = mixer.blend(Consent, name='email_marketing')
-        mixer.blend(LegalBasis, key=None, phone='',  key_type='email', email='foo@bar.com', consents=c)
-        assert command._should_update('foo@bar.com')
+        c = mixer.blend(Consent, name="email_marketing")
+        mixer.blend(
+            LegalBasis,
+            key=None,
+            phone="",
+            key_type="email",
+            email="foo@bar.com",
+            consents=c,
+        )
+        assert command._should_update("foo@bar.com")
 
     def test_should_update_doesnt_exist(self):
         out = io.StringIO()
         command = poll_maxemail.Command(stdout=out)
-        assert command._should_update('foo@bar.com')
+        assert command._should_update("foo@bar.com")


### PR DESCRIPTION
- adds API endpoint to return flattened consent data instead of Consent objects nested in LegalBasis objects
- adds initial Consent objects data migration, derived from `settings.CONSENT_TYPES`
- update `TestMaxemailCommand` to account for initial Consent data