### PR TITLE
Import CSV Consent Management Command

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -554,6 +554,7 @@ test = ["pytest", "pytest-cov", "pytest-sugar", "flake8 (3.0.4)", "requests-mock
 reference = "c9e58f82003433cad5a870caccd12fed079326c9"
 type = "git"
 url = "https://github.com/uktrade/django-staff-sso-client.git"
+
 [[package]]
 category = "main"
 description = "Structured Logging for Django"
@@ -1903,6 +1904,14 @@ six = ">=1.10.0"
 
 [[package]]
 category = "main"
+description = "Convert string to boolean"
+name = "str2bool"
+optional = false
+python-versions = "*"
+version = "1.1"
+
+[[package]]
+category = "main"
 description = "Structured Logging for Python"
 name = "structlog"
 optional = false
@@ -1930,6 +1939,24 @@ version = "2.5.0"
 jsonschema = "*"
 pyyaml = "*"
 six = "*"
+
+[[package]]
+category = "main"
+description = "Format agnostic tabular data library (XLS, JSON, YAML, CSV)"
+name = "tablib"
+optional = false
+python-versions = ">=3.5"
+version = "1.1.0"
+
+[package.extras]
+all = ["markuppy", "odfpy", "openpyxl (>=2.4.0)", "pandas", "pyyaml", "tabulate", "xlrd", "xlwt"]
+cli = ["tabulate"]
+html = ["markuppy"]
+ods = ["odfpy"]
+pandas = ["pandas"]
+xls = ["xlrd", "xlwt"]
+xlsx = ["openpyxl (>=2.4.0)"]
+yaml = ["pyyaml"]
 
 [[package]]
 category = "dev"
@@ -2149,7 +2176,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "9f3ad97889bb864922f878ac348099ed0128f717798bebea7f3c3c227d82308d"
+content-hash = "daeaaf76a370332890a80dbee18f865b2a82d0456455d087e77ea70831b4237f"
 python-versions = "3.7.*"
 
 [metadata.files]
@@ -3037,6 +3064,9 @@ stevedore = [
     {file = "stevedore-1.32.0-py2.py3-none-any.whl", hash = "sha256:a4e7dc759fb0f2e3e2f7d8ffe2358c19d45b9b8297f393ef1256858d82f69c9b"},
     {file = "stevedore-1.32.0.tar.gz", hash = "sha256:18afaf1d623af5950cc0f7e75e70f917784c73b652a34a12d90b309451b5500b"},
 ]
+str2bool = [
+    {file = "str2bool-1.1.zip", hash = "sha256:dbc3c917dca831904bce8568f6fb1f91435fcffc2ec4a46d62c9aa08d7cf77c3"},
+]
 structlog = [
     {file = "structlog-20.1.0-py2.py3-none-any.whl", hash = "sha256:8a672be150547a93d90a7d74229a29e765be05bd156a35cdcc527ebf68e9af92"},
     {file = "structlog-20.1.0.tar.gz", hash = "sha256:7a48375db6274ed1d0ae6123c486472aa1d0890b08d314d2b016f3aa7f35990b"},
@@ -3044,6 +3074,10 @@ structlog = [
 swagger-spec-validator = [
     {file = "swagger-spec-validator-2.5.0.tar.gz", hash = "sha256:61f2d2a732b886cf33c2c24886565be9692e5814cacc17fd973e095b72b33e4f"},
     {file = "swagger_spec_validator-2.5.0-py2.py3-none-any.whl", hash = "sha256:8eb82682871f8d63067b455e2e055c8dd953ca260e791635b58dfe0b73ba1f43"},
+]
+tablib = [
+    {file = "tablib-1.1.0-py3-none-any.whl", hash = "sha256:80f6c3453431cedf1125f23d16b3d96b92b426495714ebf0b4dede1fa75b447d"},
+    {file = "tablib-1.1.0.tar.gz", hash = "sha256:4d1909aa3ff1c85ba97ad16176c0aeec33c8e894dc7ea6f10f2dd44701e99ba7"},
 ]
 testfixtures = [
     {file = "testfixtures-6.14.0-py2.py3-none-any.whl", hash = "sha256:799144b3cbef7b072452d9c36cbd024fef415ab42924b96aad49dfd9c763de66"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ django-cursor-pagination = "^0.1.4"
 django-redis = "^4.11.0"
 elastic-apm = "^5.4.3"
 django-allow-cidr = "^0.3.1"
+tablib = "^1.1.0"
+str2bool = "^1.1"
 
 
 [tool.poetry.dev-dependencies]

--- a/server/apps/main/management/commands/example.csv
+++ b/server/apps/main/management/commands/example.csv
@@ -1,0 +1,2 @@
+email,accepts_dit_email_marketing,modified_at
+foo@bar.com,TRUE,2015-05-01T00:00:01Z

--- a/server/apps/main/management/commands/import_email_consent.py
+++ b/server/apps/main/management/commands/import_email_consent.py
@@ -1,0 +1,67 @@
+import argparse
+
+import tablib
+from dateutil.parser import parse
+from django.utils.functional import cached_property
+from django.utils.timezone import now
+from django_tqdm import BaseCommand
+from str2bool import str2bool
+
+from server.apps.main.models import KEY_TYPE, Commit, Consent, LegalBasis
+
+
+class Command(BaseCommand):
+    help = """
+    Start polling for forms api submissions in activity stream.
+
+    csv columns should be:
+    email,accepts_dit_email_marketing,modified_at
+
+    e.g. ./manage.py import_email_consent filename.csv
+    see server/apps/main/management/commands/example.csv for an example
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv", type=argparse.FileType("r"))
+
+    @cached_property
+    def email_consent(self):
+        email_consent, _ = Consent.objects.get_or_create(name="email_marketing")
+        return email_consent
+
+    def _update_email_consent(
+        self, commit, email_address, email_contact_consent, modified_at
+    ) -> None:
+        if email_address:
+            obj: LegalBasis = LegalBasis(
+                email=email_address,
+                commit=commit,
+                key_type=KEY_TYPE.EMAIL,
+                modified_at=modified_at,
+            )
+            obj.save()
+            if email_contact_consent:
+                obj.consents.add(self.email_consent)
+            else:
+                obj.consents.remove(self.email_consent)
+
+    def handle(self, *args, **options):
+        input_csv = options["csv"]
+        dataset = tablib.Dataset().load(input_csv)
+        row_count = len(dataset)
+
+        commit = Commit(
+            extra={"import_time": now().isoformat(), "row_count": row_count}
+        )
+
+        commit.source = "management command: import_email_consent"
+        commit.save()
+        with self.tqdm(total=row_count) as progress_bar:
+            for row in dataset.dict:
+                self._update_email_consent(
+                    commit,
+                    row["email"],
+                    str2bool(row["accepts_dit_email_marketing"]),
+                    parse(row["modified_at"]),
+                )
+                progress_bar.update(1)


### PR DESCRIPTION
New management command called `import_email_consent` that allows importing the
existing records from other systems. Built to handle the transition of consent
data from data hub to this system but can be used for any other imports too.