### PR TITLE
changing default X_FORWARDED_PROTO to http

### DIFF
--- a/server/settings/environments/default.py
+++ b/server/settings/environments/default.py
@@ -74,4 +74,4 @@ NPLUSONE_LOG_LEVEL = logging.WARN
 
 LOGGING["loggers"]["django_structlog"]["handlers"] = ["console"]  # type: ignore
 
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "http")


### PR DESCRIPTION
As CF enforces https for this header for external requests, it is safe to default it http. Which might be the reason for next and previous links to https within paginated results.