### PR TITLE
Fix protocol for pagination links

### DIFF
--- a/server/apps/main/middleware.py
+++ b/server/apps/main/middleware.py
@@ -162,10 +162,12 @@ class SslRedirectExemptHostnamesMiddleware:
         ]
 
     def __call__(self, request):
+        request.is_allow_secure_middleware_active = True
         host = self.redirect_host or request.get_host()
 
         if self.redirect and any(
             pattern.search(host) for pattern in self.redirect_exempt_hostnames
         ):
+            request.is_allow_secure_middleware_active = False
             request.META["HTTP_X_FORWARDED_PROTO"] = "https"
         return self.get_response(request)

--- a/tests/test_apps/test_main/test_views/test_legal_basis_viewset.py
+++ b/tests/test_apps/test_main/test_views/test_legal_basis_viewset.py
@@ -30,3 +30,20 @@ class TestLegalBasisViewSet:
         assert response.status_code == 200
         assert response.data["count"] == 1
         assert len(response.data["results"][0]["consents"]) == 1
+
+    def test_list_endpoint_paging(self, authenticated_client):
+        """Tests pagination of results."""
+        mixer.cycle(2).blend(LegalBasis, consents__name=mixer.sequence("email_{0}"), key=None, phone='')
+
+        url = reverse('v1:legalbasis-list')
+        response = authenticated_client.get(
+            url,
+            data={
+                'offset': 1,
+                'limit': 1,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.data['count'] > 1
+        assert len(response.data['results']) == 1


### PR DESCRIPTION
This PR is to add appropriate protocol, `http` or `https` depending on the host name. If the host name is internal, then `http` is enforced. Otherwise it defaults to `https`.