### PR TITLE
fix paging of maxemail list members

### DIFF
--- a/server/apps/poller/api_client/maxemail.py
+++ b/server/apps/poller/api_client/maxemail.py
@@ -1,5 +1,5 @@
 from collections import MutableMapping
-from typing import Optional
+from typing import Dict, Generator, List, Optional
 
 import requests
 from django.conf import settings
@@ -29,17 +29,39 @@ class MaxEmail:
                 return list_item
         return None
 
-    def get_members_for_list(self, list_id, start=0, limit=5000) -> MutableMapping:
-        return self._make_request(
-            "list",
-            data={
-                "method": "fetchRecipientsData",
-                "listId": list_id,
-                "profileFields": "[]",
-                "limit": limit,
-                "start": start,
-                "sort": "update_ts",
-                "dir": "DESC",
-                "filter": "[]",
-            },
-        )
+    def get_members_for_list(self, list_id, limit=5000) -> Generator:
+        """
+        Generator yielding one record at a time for the given `list_id`
+
+        It navigates through all pages with default limit of 5000 records per request
+        """
+        def get_members_for_page(list_id, offset=0, limit=5000) -> MutableMapping:
+            return self._make_request(
+                "list",
+                data={
+                    "method": "fetchRecipientsData",
+                    "listId": list_id,
+                    "profileFields": "[]",
+                    "limit": limit,
+                    "start": offset,
+                    "sort": "update_ts",
+                    "dir": "DESC",
+                    "filter": "[]",
+                },
+            )
+
+        def get_results(list_id)  -> Generator:
+            pos = 0
+            results = get_members_for_page(list_id, offset=0, limit=limit)
+            num_records = int(results["list_total"])
+            records: List[Dict] = []
+            while pos < num_records:
+                records = results["records"]
+                yield records
+                pos += int(results["count"])
+                results = get_members_for_page(list_id, offset=pos, limit=limit)
+
+        results = get_results(list_id)
+
+        for record in results:
+            yield from record

--- a/server/apps/poller/management/commands/poll_maxemail.py
+++ b/server/apps/poller/management/commands/poll_maxemail.py
@@ -98,10 +98,10 @@ class Command(BaseCommand):
 
         unsub_list_id = self._get_unsub_list_id(client)
 
-        results = client.get_members_for_list(unsub_list_id)
-
-        for hit in results["records"]:
-            email_address = hit["email_address"]
+        count = updated = 0
+        for recipient in client.get_members_for_list(unsub_list_id):
+            count += 1
+            email_address = recipient["email_address"]
             email_parts = email_address.split("@")
             email_log_str = f"{email_parts[0][:2]}...@...{email_parts[1][-4:]}"
 
@@ -109,6 +109,9 @@ class Command(BaseCommand):
 
             if self._should_update(email_address):
                 self.update_consent(email_address)
+                updated += 1
+
+        self.write(f"Updated {updated} records out of {count} in total")
 
     def _get_unsub_list_id(self, client) -> str:
         unsub_list = client.get_unsubscribe_list()


### PR DESCRIPTION
This PR fixes paging while consuming Maxemail API to get recipients data within a list. 

https://docs.maxemail.xtremepush.com/mxm-dev/api/services/list#List-fetchRecipientsData

As per their documentation: `A maximum of 5000 records will be returned. Therefore to retrieve the complete list, the function should be iterated in a loop, with each loop's start being increased by your value for limit, until the start value is greater than the list_total returned.`

I have ran the command locally before and after fix, to make sure the it runs as intended.