### PR TITLE
feat: protect api behind read/write permissions

### DIFF
--- a/server/apps/api/serializers.py
+++ b/server/apps/api/serializers.py
@@ -63,6 +63,7 @@ class CreateLegalBasisSerializer(LegalBasisSerializer):
     modified_at = serializers.DateTimeField(required=False)
 
     def to_internal_value(self, data):
+        data = data.copy()
         data["key_type"] = "email" if data.get("email") else "phone"
         return super().to_internal_value(data)
 
@@ -84,7 +85,9 @@ class CreateLegalBasisSerializer(LegalBasisSerializer):
             raise serializers.ValidationError("One of email or phone must be supplied")
 
         if all([attrs.get("email"), attrs.get("phone")]):
-            raise serializers.ValidationError("Both email or phone must not be supplied")
+            raise serializers.ValidationError(
+                "Both email or phone must not be supplied"
+            )
 
         return super().validate(attrs)
 

--- a/server/apps/main/permissions.py
+++ b/server/apps/main/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework.permissions import DjangoModelPermissions
+
+
+class LegalBasisModelPermissions(DjangoModelPermissions):
+    perms_map = {
+        "GET": ["%(app_label)s.view_%(model_name)s"],
+        "OPTIONS": [],
+        "HEAD": [],
+        "POST": ["%(app_label)s.add_%(model_name)s"],
+        "PUT": ["%(app_label)s.change_%(model_name)s"],
+        "PATCH": ["%(app_label)s.change_%(model_name)s"],
+        "DELETE": ["%(app_label)s.delete_%(model_name)s"],
+    }

--- a/server/settings/components/drf.py
+++ b/server/settings/components/drf.py
@@ -10,7 +10,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.DjangoModelPermissions",
+        "server.apps.main.permissions.LegalBasisModelPermissions",
     ],
     "ORDERING_PARAM": "sortby",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",

--- a/tests/test_apps/test_main/test_views/test_hawk_auth.py
+++ b/tests/test_apps/test_main/test_views/test_hawk_auth.py
@@ -1,0 +1,60 @@
+from django.contrib.auth.models import Group, Permission, User
+from django.urls import reverse
+from requests_hawk import HawkAuth
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APILiveServerTestCase, RequestsClient
+
+
+class TestHawkAuth(APILiveServerTestCase):
+    def setUp(self):
+        self.client = RequestsClient()
+        self.url = 'http://testserver' + reverse('v1:legalbasis-list')
+        self.user = User.objects.create_user(username="read-only", password="password")
+        group = Group.objects.create(name="Read only users")
+        group.permissions.add(
+            Permission.objects.get(codename="view_legalbasis"),
+            Permission.objects.get(codename="view_consent"),
+        )
+        self.user.groups.add(group)
+
+    def test_no_auth(self):
+        response = self.client.get(
+            self.url
+        )
+        assert response.status_code == 401
+
+    def test_invalid_key(self):
+        Token.objects.create(user=self.user, key='valid-user-key')
+        hawk_auth = HawkAuth(id=self.user.username, key='invalid-user-key')
+        response = self.client.get(
+            self.url,
+            auth=hawk_auth,
+        )
+        assert response.status_code == 401
+
+    def test_user_does_not_exist(self):
+        hawk_auth = HawkAuth(id='i-dont-exist', key='non-existent-user-key')
+        response = self.client.get(
+            self.url,
+            auth=hawk_auth,
+        )
+        assert response.status_code == 401
+
+    def test_valid_key_no_permission(self):
+        user = User.objects.create_user(username="no-perms", password="password")
+        token = Token.objects.create(user=user, key='valid-user-key')
+        hawk_auth = HawkAuth(id=user.username, key=token.key)
+        response = self.client.get(
+            self.url,
+            auth=hawk_auth,
+        )
+        assert response.status_code == 403
+
+    def test_valid_key(self):
+        token = Token.objects.create(user=self.user, key='valid-user-key')
+        hawk_auth = HawkAuth(id=self.user.username, key=token.key)
+        response = self.client.get(
+            self.url,
+            auth=hawk_auth,
+        )
+        assert response.status_code == 200

--- a/tests/test_apps/test_main/test_views/test_legal_basis_viewset.py
+++ b/tests/test_apps/test_main/test_views/test_legal_basis_viewset.py
@@ -8,36 +8,19 @@ from server.apps.main.models import LegalBasis
 class TestLegalBasisViewSet:
     pytestmark = pytest.mark.django_db
 
-    def test_list_endpoint(self, authenticated_client):
-        """This test ensures that list endpoint works."""
-        response = authenticated_client.get(reverse("v1:legalbasis-list"))
-
-        assert response.status_code == 200
-        assert response.data["count"] == 0
-
-    @pytest.mark.skip
     def test_list_endpoint_by_unauthenticated(self, client):
         """This test ensures that list endpoint works requires being logged in."""
         response = client.get(reverse("v1:legalbasis-list"))
-
         assert response.status_code == 401
 
-    def test_list_endpoint_with_1_item(self, authenticated_client):
-        """This test ensures that list endpoint works."""
-        mixer.blend(LegalBasis, consents__name="email", key=None, phone='')
-
-        response = authenticated_client.get(reverse("v1:legalbasis-list"))
-
-        assert response.status_code == 200
-        assert response.data["count"] == 1
-        assert len(response.data["results"][0]["consents"]) == 1
-
-    def test_list_endpoint_paging(self, authenticated_client):
+    def test_list_endpoint_paging(self, read_only_client):
         """Tests pagination of results."""
-        mixer.cycle(2).blend(LegalBasis, consents__name=mixer.sequence("email_{0}"), key=None, phone='')
+        mixer.cycle(2).blend(
+            LegalBasis, consents__name=mixer.sequence("email_{0}"), key=None, phone=''
+        )
 
         url = reverse('v1:legalbasis-list')
-        response = authenticated_client.get(
+        response = read_only_client.get(
             url,
             data={
                 'offset': 1,
@@ -49,15 +32,19 @@ class TestLegalBasisViewSet:
         assert response.data['count'] > 1
         assert len(response.data['results']) == 1
 
-    def test_bulk_lookup_endpoint(self, authenticated_client):
+    def test_bulk_lookup_endpoint(self, read_write_client):
         """Test bulk lookup endpoint."""
         emails = ['foo_0@bar.com', 'foo_1@bar.com']
         mixer.cycle(2).blend(
-            LegalBasis, key=None, phone="", key_type="email", email=(email for email in emails)
+            LegalBasis,
+            key=None,
+            phone="",
+            key_type="email",
+            email=(email for email in emails),
         )
 
         url = reverse('v1:legalbasis-bulk-lookup')
-        response = authenticated_client.post(
+        response = read_write_client.post(
             url,
             data={
                 'emails': [emails[0].upper(), emails[1]],
@@ -69,3 +56,102 @@ class TestLegalBasisViewSet:
 
         result_emails = [result['email'] for result in response.data['results']]
         assert result_emails == emails
+
+    def test_read_only_bulk_lookup(self, read_only_client):
+        lb1 = mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        mixer.blend(LegalBasis, consents__name="phone", key=None, email="")
+        response = read_only_client.post(
+            reverse("v1:legalbasis-bulk-lookup"),
+            data={"emails": [lb1.email]},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_user_with_no_permissions(self, authenticated_client):
+        mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        response = authenticated_client.get(reverse("v1:legalbasis-list"))
+        assert response.status_code == 403
+
+    def test_read_write_user_can_read(self, read_write_client):
+        mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        response = read_write_client.get(reverse("v1:legalbasis-list"))
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert len(response.data["results"][0]["consents"]) == 1
+
+    def test_read_write_user_can_write(self, read_write_client):
+        mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        legal_basis_count = LegalBasis.objects.all().count()
+        response = read_write_client.post(
+            reverse("v1:legalbasis-list"),
+            data={"email": "test.email@example.com", "consents": ["email"]},
+            format="json",
+        )
+        assert response.status_code == 201
+        assert response.data["email"] == "test.email@example.com"
+        assert response.data["phone"] == ""
+        assert response.data["consents"] == ["email"]
+        assert LegalBasis.objects.all().count() == legal_basis_count + 1
+
+    def test_read_only_user_can_read(self, read_only_client):
+        mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        response = read_only_client.get(reverse("v1:legalbasis-list"))
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert len(response.data["results"][0]["consents"]) == 1
+
+    def test_read_only_user_cannot_write(self, read_only_client):
+        legal_basis_count = LegalBasis.objects.all().count()
+        response = read_only_client.post(
+            reverse("v1:legalbasis-list"),
+            data={
+                "email": "this.wont.work@example.com",
+                "consents": ["email_marketing"],
+            },
+            format="json",
+        )
+        assert response.status_code == 403
+        assert LegalBasis.objects.all().count() == legal_basis_count
+
+    def test_write_only_user_cannot_read(self, write_only_client):
+        mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        response = write_only_client.get(reverse("v1:legalbasis-list"))
+        assert response.status_code == 403
+
+    def test_write_only_user_can_write(self, write_only_client):
+        mixer.blend(LegalBasis, consents__name="phone", key=None, phone="")
+        legal_basis_count = LegalBasis.objects.all().count()
+        response = write_only_client.post(
+            reverse("v1:legalbasis-list"),
+            data={"phone": "+447897395794", "consents": ["phone_marketing"]},
+            format="json",
+        )
+        assert response.status_code == 201
+        assert response.data["email"] == ""
+        assert response.data["phone"] == "+447897395794"
+        assert response.data["consents"] == ["phone_marketing"]
+        assert LegalBasis.objects.all().count() == legal_basis_count + 1
+
+    def test_write_only_datahub_export(self, write_only_client):
+        mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        response = write_only_client.get(reverse("v1:legalbasis-datahub-export"))
+        assert response.status_code == 403
+
+    def test_read_write_datahub_export(self, read_write_client):
+        lb = mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        response = read_write_client.get(reverse("v1:legalbasis-datahub-export"))
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == lb.id
+
+    def test_read_write_bulk_lookup(self, read_write_client):
+        lb1 = mixer.blend(LegalBasis, consents__name="email", key=None, phone="")
+        mixer.blend(LegalBasis, consents__name="phone", key=None, email="")
+        response = read_write_client.post(
+            reverse("v1:legalbasis-bulk-lookup"),
+            data={"emails": [lb1.email]},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert len(response.data["results"][0]["consents"]) == 1


### PR DESCRIPTION
- Protect api endpoints behind model level read/write permissions.
- Adds some tests for hawk auth

Before go live we will need to update the relevant environments to create read/read write permission groups and apply them to the relevant users.