### PR TITLE
feat: remove x-xss-protection header

### DIFF
--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -265,7 +265,6 @@ def add_whitenoise_headers(headers, _path, _url):
     headers["Pragma"] = "no-cache"
     headers["X-Content-Type-Options"] = "nosniff"
     headers["X-Frame-Options"] = "DENY"
-    headers["X-XSS-Protection"] = "0"
 
 
 WHITENOISE_ADD_HEADERS_FUNCTION = add_whitenoise_headers


### PR DESCRIPTION
Think it's acceptable to just not include this header anywhere. Plus, I'm not convinced this line of code does anything anyway.