### PR TITLE
fix: accessing email consent in combined consent

### DIFF
--- a/server/apps/poller/management/commands/poll_formsapi.py
+++ b/server/apps/poller/management/commands/poll_formsapi.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
     @transaction.atomic()
     def update_consent(self, object_data, meta) -> None:
         email_address = object_data.get("email_address", object_data.get("email"))
-        email_contact_consent = object_data.get("email_contact_consent") or object_data.get("contact_consent")
+        email_contact_consent = object_data.get("email_contact_consent") or "consents_to_email_contact" in object_data.get("contact_consent", [])
 
         phone_number = object_data.get("phone_number")
         phone_number_country = object_data.get("country")

--- a/tests/test_apps/test_poller/test_managment_commands/test_poll_formsapi.py
+++ b/tests/test_apps/test_poller/test_managment_commands/test_poll_formsapi.py
@@ -40,7 +40,7 @@ class TestFormsAPICommand:
             hit.object = {
                 'dit:directoryFormsApi:Submission:Data': AttrDict({
                     'email_address': 'foo@bar.com',
-                    'contact_consent': True,
+                    'contact_consent': ['consents_to_email_contact'],
                 })
             }
             hit.to_dict.return_value = {


### PR DESCRIPTION
Previous PR assumed "contact_consent" was a bool when it is a list, this should return true if email consent is given inside this list