### PR TITLE
build(deps): bump Docker Python to match prod

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile uses multi-stage build to customize DEV and PROD images:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM python:3.7-alpine as development_build
+FROM python:3.9-alpine as development_build
 
 LABEL maintainer="legal_basis_api@Department for International Trade"
 LABEL vendor="Department for International Trade"


### PR DESCRIPTION
 The Dockerfile wasn't building - suspect some recent requirements changes have caused errors like:

> Requires-Python >=3.8

when building