### PR TITLE
feat: avoid exception if phone number is > 128 characters long

### DIFF
--- a/server/apps/poller/management/commands/poll_formsapi.py
+++ b/server/apps/poller/management/commands/poll_formsapi.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
                 pass
 
             obj = LegalBasis(
-                phone=phone_number, commit=commit, key_type=KEY_TYPE.PHONE,
+                phone=phone_number[:128], commit=commit, key_type=KEY_TYPE.PHONE,
             )
             obj.save()
             if phone_consent:


### PR DESCRIPTION
It's probably not a real phone number, so shouldn't increase the length of the field I suspect.