### PR TITLE
fix: add ordering to paginated response

### DIFF
--- a/server/apps/api/views/legal_basis.py
+++ b/server/apps/api/views/legal_basis.py
@@ -57,7 +57,7 @@ class LegalBasisViewSet(viewsets.ModelViewSet):
     and returns their consent status.
     """
 
-    queryset = LegalBasis.objects.prefetch_related("consents").filter(current=True)
+    queryset = LegalBasis.objects.prefetch_related("consents").filter(current=True).order_by('id')
     serializer_class = LegalBasisSerializer
     create_serializer_class = CreateLegalBasisSerializer
     filter_backends = [DjangoFilterBackend]


### PR DESCRIPTION
The data-flow pipeline is failing due to primary key duplication. It's suspected that the lack of ordering on paginated responses causes this - data can be duplicated between pages because no global ordering is enforced.

This would be worse when there are changes to legal basis during the run of a pipeline, and we're now making more changes to legal basis because of recent fixes to the Forms API poller.