### PR TITLE
Add export CSV button to admin for all legal basis

### DIFF
--- a/server/apps/admin_export/urls.py
+++ b/server/apps/admin_export/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+
+from server.apps.admin_export.views import ExportLegalBasisCSV
+
+
+app_name = "admin_export"
+
+urlpatterns = [
+    path(
+        "legal-basis-export", ExportLegalBasisCSV.as_view(), name="legal-basis-export"
+    ),
+]

--- a/server/apps/admin_export/views.py
+++ b/server/apps/admin_export/views.py
@@ -1,0 +1,67 @@
+import csv
+from typing import Iterator, List
+
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import QuerySet
+from django.http import StreamingHttpResponse
+from django.views import View
+
+from server.apps.main.models import LegalBasis
+
+
+class Echo:
+    """
+    An object that implements just the write method of the file-like
+    interface.
+    """
+
+    def write(self, value):
+        """Write the value by returning it, instead of storing in a buffer."""
+        return value
+
+
+class ExportLegalBasisCSV(View):
+    http_method_names = ["get"]
+
+    def get(self, request) -> StreamingHttpResponse:
+        return StreamingHttpResponse(
+            (self.iter_items(self.get_queryset(), Echo())),
+            content_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="legal_basis.csv"'},
+        )
+
+    def iter_items(self, items, pseudo_buffer) -> Iterator[str]:
+        """Writes the values including the headings for the StreamingHttpResponse."""
+        writer = csv.DictWriter(pseudo_buffer, fieldnames=self.get_columns())
+        yield pseudo_buffer.write(f"{','.join(self.get_columns())}\n")
+
+        for item in items:
+            yield writer.writerow(item)
+
+    def get_queryset(self) -> QuerySet:
+        """Returns a list of LegalBasis data for CSV export."""
+        return (
+            LegalBasis.objects.select_related("commit")
+            .prefetch_related("consents")
+            .annotate(
+                consents_name=ArrayAgg("consents__name"),
+                consents_description=ArrayAgg("consents__description"),
+            )
+            .values(*self.get_columns())
+        )
+
+    def get_columns(self) -> List[str]:
+        """Values for the LegalBasis table, also used for CSV headers."""
+        return [
+            "email",
+            "phone",
+            "key_type",
+            "created_at",
+            "modified_at",
+            "current",
+            "commit__created_at",
+            "commit__source",
+            "commit__extra",
+            "consents_name",
+            "consents_description",
+        ]

--- a/server/apps/main/admin.py
+++ b/server/apps/main/admin.py
@@ -9,11 +9,11 @@ from server.apps.main.models import Commit, Consent, LegalBasis, LegalBasisCurre
 
 class LegalBasisAdmin(admin.ModelAdmin):
 
+    change_list_template = 'admin/change_list_csv_export.html'
     search_fields = ("email", "phone")
-
     readonly_fields = ("key", "current")
-
     list_display = ("key_type", "email", "phone", "modified_at")
+    actions = ["export_as_csv"]
 
     def export_as_csv(self, request, queryset):
         consent_types = list(Consent.objects.all().values_list("name", flat=True))

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -39,6 +39,7 @@ INSTALLED_APPS: Tuple[str, ...] = (
     "server.apps.main",
     "server.apps.api",
     "server.apps.poller",
+    "server.apps.admin_export",
     # 3rd party django apps
     "rest_framework",
     "rest_framework.authtoken",

--- a/server/templates/admin/change_list_csv_export.html
+++ b/server/templates/admin/change_list_csv_export.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static admin_list %}
+
+{% block object-tools-items %}
+{{ block.super }}
+<li>
+    <a href="{% url 'admin_export:legal-basis-export' %}" target="_blank" class="btn btn-high btn-success">Export to CSV</a>
+</li>
+{% endblock %}

--- a/server/urls.py
+++ b/server/urls.py
@@ -24,6 +24,8 @@ admin.autodiscover()
 urlpatterns = [
     # Apps:
     path("api/v1/", include(api_urls, namespace="v1")),
+    # Admin Export:
+    path("admin-export/", include('server.apps.admin_export.urls')),
     # Health checks:
     path("health/", include(health_urls)),  # noqa: DJ05
     # Django Admin Oauth2


### PR DESCRIPTION
Adds a button to the admin legal basis list page. This button allows all legal basis to be exported into a CSV.

<img width="1499" alt="Screenshot 2024-03-28 at 14 26 38" src="https://github.com/uktrade/legal-basis-api/assets/22541658/6275b2be-37e4-4290-94df-e9d238b79968">
