### PR TITLE
Add timeout to manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - buildpacks:
       - python_buildpack
+    timeout: 360
     stack: cflinuxfs4
     health-check-type: http
     health-check-http-endpoint: /health


### PR DESCRIPTION
Updates Jenkins build timeout to 6 minutes instead of 3