### PR TITLE
fix: disable ssl redirect as it's not necessary on paas

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - buildpacks:
       - python_buildpack
-    timeout: 360
+    timeout: 180
     stack: cflinuxfs4
     health-check-type: http
     health-check-http-endpoint: /health

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -209,6 +209,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SILENCED_SYSTEM_CHECKS = [
     # Don't enforce SECURE_BROWSER_XSS_FILTER, which is recommended to be disabled
     "security.W007",
+    "security.W008",
 ]
 
 X_FRAME_OPTIONS = "DENY"

--- a/server/settings/environments/production.py
+++ b/server/settings/environments/production.py
@@ -28,7 +28,7 @@ STORAGES = {
     },
     "staticfiles": {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
-    }
+    },
 }
 
 # Password validation
@@ -50,7 +50,7 @@ SECURE_HSTS_SECONDS = 31536000  # the same as Caddy has
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
 
-SECURE_SSL_REDIRECT = True
+SECURE_SSL_REDIRECT = False
 SECURE_SSL_REDIRECT_EXEMPT_HOSTNAMES = (r"\.apps\.internal:8080$",)
 
 SESSION_COOKIE_SECURE = True
@@ -60,5 +60,7 @@ SENTRY_DSN = env.str("SENTRY_DSN", default=None)
 
 if SENTRY_DSN is not None:
     sentry_sdk.hub.init(
-        dsn=SENTRY_DSN, integrations=[DjangoIntegration()], send_default_pii=True,
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        send_default_pii=True,
     )


### PR DESCRIPTION
Using SECURE_SSL_REDIRECT causes an infinet redirect loop. This setting is not necessary on paas anyway as all requests are https