### PR TITLE
adds missing slash

### DIFF
--- a/server/apps/poller/api_client/dynamics.py
+++ b/server/apps/poller/api_client/dynamics.py
@@ -18,9 +18,9 @@ CONSENT_OPTED_OUT = 534120002
 class DynamicsClient:
     token: str
     max_retry_attempts: int = 10
-    contacts_url: str = f"{settings.DYNAMICS_INSTANCE_URI}api/data/v9.2/contacts"
+    contacts_url: str = f"{settings.DYNAMICS_INSTANCE_URI}/api/data/v9.2/contacts"
     consents_url: str = (
-        f"{settings.DYNAMICS_INSTANCE_URI}api/data/v9.2/msdynmkt_contactpointconsent4s"
+        f"{settings.DYNAMICS_INSTANCE_URI}/api/data/v9.2/msdynmkt_contactpointconsent4s"
     )
 
     def __init__(self) -> None:


### PR DESCRIPTION
Dynamics poller is currently not running with this error:
`ERR requests.exceptions.ConnectionError: HTTPSConnectionPool(host='dbt.crm11.dynamics.comapi', port=443): Max retries exceeded with url: /data/v9.2/msdynmkt_contactpointconsent4s (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fcb98873550>: Failed to establish a new connection: [Errno -2] Name or service not known'))`

It is evident from the host name appeared above `dbt.crm11.dynamics.comapi` that the `/` that should have been there is missing. As this could have been removed from both code and Vault by mistake.

So this PR fixes it, and add this `/` back in the code. Vault remains as is, without `/`. 