### PR TITLE
fix: only process hits with email consent given

### DIFF
--- a/server/apps/poller/api_client/activity.py
+++ b/server/apps/poller/api_client/activity.py
@@ -36,7 +36,7 @@ class FormsApi(ActivityStreamClient):
         if "object" in hit:
             if f"{self.name}:Data" in hit.object:
                 data = hit.object[f"{self.name}:Data"]
-                if "email_contact_consent" or "contact_consent" in data:
+                if "email_contact_consent" in data or "contact_consent" in data:
                     return True
                 # if "phone_number" in data:
                 #     return True


### PR DESCRIPTION
The previous 'if' statement was intended to check if the 2 ways of recording consent were present in data, but this was working incorrectly and only checking 'if "email_consent"' which should default to True.